### PR TITLE
Fixed an issue with base64 encoding activityId/placementId to create a scope

### DIFF
--- a/code/optimize/src/androidTest/java/com/adobe/marketing/mobile/optimize/OptimizeFunctionalTests.java
+++ b/code/optimize/src/androidTest/java/com/adobe/marketing/mobile/optimize/OptimizeFunctionalTests.java
@@ -78,7 +78,7 @@ public class OptimizeFunctionalTests {
         Assert.assertEquals(OptimizeTestConstants.EXTENSION_VERSION, Optimize.extensionVersion());
     }
 
-    //2
+    //2a
     @Test
     public void testUpdatePropositions_validDecisionScope() throws InterruptedException {
         //Setup
@@ -120,6 +120,99 @@ public class OptimizeFunctionalTests {
         Assert.assertNotNull(decisionScopeList);
         Assert.assertEquals(1, decisionScopeList.size());
         Assert.assertEquals(decisionScopeName, decisionScopeList.get(0));
+    }
+
+    //2b
+    @Test
+    public void testUpdatePropositions_validNonEncodedDecisionScope() throws InterruptedException {
+        //Setup
+        final String activityId = "xcore:offer-activity:1111111111111111";
+        final String placementId = "xcore:offer-placement:1111111111111111";
+
+        Map<String, Object> configData = new HashMap<>();
+        configData.put("edge.configId", "ffffffff-ffff-ffff-ffff-ffffffffffff");
+        MobileCore.updateConfiguration(configData);
+
+        //Action
+        Optimize.updatePropositions(Collections.singletonList(new DecisionScope(activityId, placementId)), null, null);
+
+        //Assert
+        List<Event> eventsListOptimize = TestHelper.getDispatchedEventsWith(OptimizeTestConstants.EventType.OPTIMIZE, OptimizeTestConstants.EventSource.REQUEST_CONTENT, 1000);
+        List<Event> eventsListEdge = TestHelper.getDispatchedEventsWith(OptimizeTestConstants.EventType.EDGE, OptimizeTestConstants.EventSource.REQUEST_CONTENT, 1000);
+
+        Assert.assertNotNull(eventsListOptimize);
+        Assert.assertNotNull(eventsListEdge);
+        Assert.assertEquals(1, eventsListOptimize.size());
+        Assert.assertEquals(1, eventsListEdge.size());
+        Event event = eventsListOptimize.get(0);
+        Map<String, Object> eventData = event.getEventData();
+        Assert.assertEquals(OptimizeTestConstants.EventType.OPTIMIZE.toLowerCase(), event.getType());
+        Assert.assertEquals(OptimizeTestConstants.EventSource.REQUEST_CONTENT.toLowerCase(), event.getSource());
+        Assert.assertTrue(eventData.size() > 0);
+        Assert.assertEquals("updatepropositions", eventData.get("requesttype"));
+        List<Map<String, String>> decisionScopes = (List<Map<String, String>>) eventData.get("decisionscopes");
+        Assert.assertEquals(1, decisionScopes.size());
+        Assert.assertEquals("eyJhY3Rpdml0eUlkIjoieGNvcmU6b2ZmZXItYWN0aXZpdHk6MTExMTExMTExMTExMTExMSIsInBsYWNlbWVudElkIjoieGNvcmU6b2ZmZXItcGxhY2VtZW50OjExMTExMTExMTExMTExMTEifQ==", decisionScopes.get(0).get("name"));
+
+        //Validating Event data of Edge Request event
+        Event edgeEvent = eventsListEdge.get(0);
+        Assert.assertNotNull(edgeEvent);
+        Map<String, Object> edgeEventData = edgeEvent.getEventData();
+        Assert.assertNotNull(edgeEventData);
+        Assert.assertTrue(edgeEventData.size() > 0);
+        Assert.assertEquals("personalization.request", ((Map<String, Object>) edgeEventData.get("xdm")).get("eventType"));
+        Map<String, Object> personalizationMap = (Map<String, Object>) ((Map<String, Object>) edgeEventData.get("query")).get("personalization");
+        List<String> decisionScopeList = (List<String>) personalizationMap.get("decisionScopes");
+        Assert.assertNotNull(decisionScopeList);
+        Assert.assertEquals(1, decisionScopeList.size());
+        Assert.assertEquals("eyJhY3Rpdml0eUlkIjoieGNvcmU6b2ZmZXItYWN0aXZpdHk6MTExMTExMTExMTExMTExMSIsInBsYWNlbWVudElkIjoieGNvcmU6b2ZmZXItcGxhY2VtZW50OjExMTExMTExMTExMTExMTEifQ==", decisionScopeList.get(0));
+    }
+
+    //2c
+    @Test
+    public void testUpdatePropositions_validNonEncodedDecisionScopeWithItemCount() throws InterruptedException {
+        //Setup
+        final String activityId = "xcore:offer-activity:1111111111111111";
+        final String placementId = "xcore:offer-placement:1111111111111111";
+        final int itemCount = 30;
+
+        Map<String, Object> configData = new HashMap<>();
+        configData.put("edge.configId", "ffffffff-ffff-ffff-ffff-ffffffffffff");
+        MobileCore.updateConfiguration(configData);
+
+        //Action
+        Optimize.updatePropositions(Collections.singletonList(new DecisionScope(activityId, placementId, itemCount)), null, null);
+
+        //Assert
+        List<Event> eventsListOptimize = TestHelper.getDispatchedEventsWith(OptimizeTestConstants.EventType.OPTIMIZE, OptimizeTestConstants.EventSource.REQUEST_CONTENT, 1000);
+        List<Event> eventsListEdge = TestHelper.getDispatchedEventsWith(OptimizeTestConstants.EventType.EDGE, OptimizeTestConstants.EventSource.REQUEST_CONTENT, 1000);
+
+        Assert.assertNotNull(eventsListOptimize);
+        Assert.assertNotNull(eventsListEdge);
+        Assert.assertEquals(1, eventsListOptimize.size());
+        Assert.assertEquals(1, eventsListEdge.size());
+        Event event = eventsListOptimize.get(0);
+        Map<String, Object> eventData = event.getEventData();
+        Assert.assertEquals(OptimizeTestConstants.EventType.OPTIMIZE.toLowerCase(), event.getType());
+        Assert.assertEquals(OptimizeTestConstants.EventSource.REQUEST_CONTENT.toLowerCase(), event.getSource());
+        Assert.assertTrue(eventData.size() > 0);
+        Assert.assertEquals("updatepropositions", eventData.get("requesttype"));
+        List<Map<String, String>> decisionScopes = (List<Map<String, String>>) eventData.get("decisionscopes");
+        Assert.assertEquals(1, decisionScopes.size());
+        Assert.assertEquals("eyJhY3Rpdml0eUlkIjoieGNvcmU6b2ZmZXItYWN0aXZpdHk6MTExMTExMTExMTExMTExMSIsInBsYWNlbWVudElkIjoieGNvcmU6b2ZmZXItcGxhY2VtZW50OjExMTExMTExMTExMTExMTEiLCJpdGVtQ291bnQiOjMwfQ==", decisionScopes.get(0).get("name"));
+
+        //Validating Event data of Edge Request event
+        Event edgeEvent = eventsListEdge.get(0);
+        Assert.assertNotNull(edgeEvent);
+        Map<String, Object> edgeEventData = edgeEvent.getEventData();
+        Assert.assertNotNull(edgeEventData);
+        Assert.assertTrue(edgeEventData.size() > 0);
+        Assert.assertEquals("personalization.request", ((Map<String, Object>) edgeEventData.get("xdm")).get("eventType"));
+        Map<String, Object> personalizationMap = (Map<String, Object>) ((Map<String, Object>) edgeEventData.get("query")).get("personalization");
+        List<String> decisionScopeList = (List<String>) personalizationMap.get("decisionScopes");
+        Assert.assertNotNull(decisionScopeList);
+        Assert.assertEquals(1, decisionScopeList.size());
+        Assert.assertEquals("eyJhY3Rpdml0eUlkIjoieGNvcmU6b2ZmZXItYWN0aXZpdHk6MTExMTExMTExMTExMTExMSIsInBsYWNlbWVudElkIjoieGNvcmU6b2ZmZXItcGxhY2VtZW50OjExMTExMTExMTExMTExMTEiLCJpdGVtQ291bnQiOjMwfQ==", decisionScopeList.get(0));
     }
 
     //3

--- a/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/OptimizeUtils.java
+++ b/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/OptimizeUtils.java
@@ -65,7 +65,7 @@ class OptimizeUtils {
         if (isNullOrEmpty(str)) {
             return str;
         }
-        return Base64.encodeToString(str.getBytes(), Base64.DEFAULT);
+        return Base64.encodeToString(str.getBytes(), Base64.NO_WRAP);
     }
 
     /**
@@ -83,7 +83,7 @@ class OptimizeUtils {
 
         String output = null;
         try {
-            output = new String(Base64.decode(str.getBytes(), Base64.DEFAULT));
+            output = new String(Base64.decode(str, Base64.DEFAULT));
         } catch(final IllegalArgumentException ex) {
             MobileCore.log(LoggingMode.DEBUG, LOG_TAG, String.format("Base64 decode failed for the given string (%s) with exception: %s", str, ex.getLocalizedMessage()));
         }

--- a/code/optimize/src/test/java/com/adobe/marketing/mobile/optimize/DecisionScopeTests.java
+++ b/code/optimize/src/test/java/com/adobe/marketing/mobile/optimize/DecisionScopeTests.java
@@ -36,6 +36,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 
 
 @RunWith(PowerMockRunner.class)
@@ -50,10 +51,10 @@ public class DecisionScopeTests {
                 return java.util.Base64.getEncoder().encodeToString((byte[]) invocation.getArguments()[0]);
             }
         });
-        Mockito.when(Base64.decode((byte[]) any(), anyInt())).thenAnswer(new Answer<byte[]>() {
+        Mockito.when(Base64.decode(anyString(), anyInt())).thenAnswer(new Answer<byte[]>() {
             @Override
             public byte[] answer(InvocationOnMock invocation) throws Throwable {
-                return java.util.Base64.getDecoder().decode((byte[]) invocation.getArguments()[0]);
+                return java.util.Base64.getDecoder().decode((String) invocation.getArguments()[0]);
             }
         });
     }

--- a/code/optimize/src/test/java/com/adobe/marketing/mobile/optimize/OptimizeExtensionTests.java
+++ b/code/optimize/src/test/java/com/adobe/marketing/mobile/optimize/OptimizeExtensionTests.java
@@ -95,10 +95,10 @@ public class OptimizeExtensionTests {
                 return java.util.Base64.getEncoder().encodeToString((byte[]) invocation.getArguments()[0]);
             }
         });
-        Mockito.when(Base64.decode((byte[]) any(), anyInt())).thenAnswer(new Answer<byte[]>() {
+        Mockito.when(Base64.decode(anyString(), anyInt())).thenAnswer(new Answer<byte[]>() {
             @Override
             public byte[] answer(InvocationOnMock invocation) throws Throwable {
-                return java.util.Base64.getDecoder().decode((byte[]) invocation.getArguments()[0]);
+                return java.util.Base64.getDecoder().decode((String) invocation.getArguments()[0]);
             }
         });
     }

--- a/code/optimize/src/test/java/com/adobe/marketing/mobile/optimize/OptimizeTests.java
+++ b/code/optimize/src/test/java/com/adobe/marketing/mobile/optimize/OptimizeTests.java
@@ -66,10 +66,10 @@ public class OptimizeTests {
                 return java.util.Base64.getEncoder().encodeToString((byte[]) invocation.getArguments()[0]);
             }
         });
-        Mockito.when(Base64.decode((byte[]) any(), anyInt())).thenAnswer(new Answer<byte[]>() {
+        Mockito.when(Base64.decode(anyString(), anyInt())).thenAnswer(new Answer<byte[]>() {
             @Override
             public byte[] answer(InvocationOnMock invocation) throws Throwable {
-                return java.util.Base64.getDecoder().decode((byte[]) invocation.getArguments()[0]);
+                return java.util.Base64.getDecoder().decode((String) invocation.getArguments()[0]);
             }
         });
     }

--- a/code/optimize/src/test/java/com/adobe/marketing/mobile/optimize/OptimizeUtilsTest.java
+++ b/code/optimize/src/test/java/com/adobe/marketing/mobile/optimize/OptimizeUtilsTest.java
@@ -35,6 +35,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(Base64.class)
@@ -48,10 +49,10 @@ public class OptimizeUtilsTest {
                 return java.util.Base64.getEncoder().encodeToString((byte[]) invocation.getArguments()[0]);
             }
         });
-        Mockito.when(Base64.decode((byte[]) any(), anyInt())).thenAnswer(new Answer<byte[]>() {
+        Mockito.when(Base64.decode(anyString(), anyInt())).thenAnswer(new Answer<byte[]>() {
             @Override
             public byte[] answer(InvocationOnMock invocation) throws Throwable {
-                return java.util.Base64.getDecoder().decode((byte[]) invocation.getArguments()[0]);
+                return java.util.Base64.getDecoder().decode((String)invocation.getArguments()[0]);
             }
         });
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Ref: [MOB-17465]

- Pass flag **Base64.NO_WRAP** when invoking android.util.Base64.encodeToString(byte[] input, int flags). Otherwise, a newline character ("\n") is included after every 76 characters in the encoded output. For details, see https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/util/Base64.java
- Updated functional tests
- Some code cleanup

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
