### PR TITLE
Added support for proposition event type

### DIFF
--- a/code/optimize/src/androidTest/java/com/adobe/marketing/mobile/optimize/OptimizeFunctionalTests.java
+++ b/code/optimize/src/androidTest/java/com/adobe/marketing/mobile/optimize/OptimizeFunctionalTests.java
@@ -1061,7 +1061,7 @@ public class OptimizeFunctionalTests {
                 "            ]\n" +
                 "        }\n";
         ObjectMapper objectMapper = new ObjectMapper();
-        Map<String, Object> testDecisionScopesMap = objectMapper.readValue(testDecisionScopes, new TypeReference<Map<String, Object>>() {});
+        final Map<String, Object> testDecisionScopesMap = objectMapper.readValue(testDecisionScopes, new TypeReference<Map<String, Object>>() {});
 
         Offer offer = new Offer.Builder("246315", OfferType.TEXT, "Text Offer!!").build();
         Proposition proposition = new Proposition(
@@ -1076,36 +1076,36 @@ public class OptimizeFunctionalTests {
         offer.tapped();
 
         //Assert
-        List<Event> optimizeRequestEventsList = TestHelper.getDispatchedEventsWith(OptimizeTestConstants.EventType.OPTIMIZE, OptimizeTestConstants.EventSource.REQUEST_CONTENT, 1000);
-        List<Event> edgeRequestEventList = TestHelper.getDispatchedEventsWith(OptimizeTestConstants.EventType.EDGE, OptimizeTestConstants.EventSource.REQUEST_CONTENT, 1000);
+        final List<Event> optimizeRequestEventsList = TestHelper.getDispatchedEventsWith(OptimizeTestConstants.EventType.OPTIMIZE, OptimizeTestConstants.EventSource.REQUEST_CONTENT, 1000);
+        final List<Event> edgeRequestEventList = TestHelper.getDispatchedEventsWith(OptimizeTestConstants.EventType.EDGE, OptimizeTestConstants.EventSource.REQUEST_CONTENT, 1000);
 
         Assert.assertNotNull(optimizeRequestEventsList);
         Assert.assertEquals(1, optimizeRequestEventsList.size());
         Assert.assertNotNull(edgeRequestEventList);
         Assert.assertEquals(1, edgeRequestEventList.size());
 
-        Map<String, Object> xdm = (Map<String, Object>) edgeRequestEventList.get(0).getEventData().get("xdm");
+        final Map<String, Object> xdm = (Map<String, Object>) edgeRequestEventList.get(0).getEventData().get("xdm");
         Assert.assertEquals("decisioning.propositionInteract", xdm.get("eventType"));
 
-        Map<String, Object> experience =  (Map<String, Object>)xdm.get("_experience");
+        final Map<String, Object> experience =  (Map<String, Object>)xdm.get("_experience");
         assertNotNull(experience);
-        Map<String, Object> decisioning =  (Map<String, Object>)experience.get("decisioning");
+        final Map<String, Object> decisioning =  (Map<String, Object>)experience.get("decisioning");
         assertNotNull(decisioning);
-        Map<String, Object> propositionEventType = (Map<String, Object>)decisioning.get("propositionEventType");
+        final Map<String, Object> propositionEventType = (Map<String, Object>)decisioning.get("propositionEventType");
         assertNotNull(propositionEventType);
         assertEquals(1, propositionEventType.get("interact"));
-        List<Map<String, Object>> propositionList = (List<Map<String, Object>>)decisioning.get("propositions");
+        final List<Map<String, Object>> propositionList = (List<Map<String, Object>>)decisioning.get("propositions");
         Assert.assertNotNull(propositionList);
         Assert.assertEquals(1, propositionList.size());
-        Map<String, Object> propositionData = propositionList.get(0);
-        List<Map<String, Object>> propositionsList = (List<Map<String, Object>>) propositionData.get("propositions");
+        final Map<String, Object> propositionData = propositionList.get(0);
+        final List<Map<String, Object>> propositionsList = (List<Map<String, Object>>) propositionData.get("propositions");
         Assert.assertNotNull(propositionList);
         Assert.assertEquals(1, propositionList.size());
-        Map<String, Object> propositionMap = propositionList.get(0);
+        final Map<String, Object> propositionMap = propositionList.get(0);
         Assert.assertEquals("AT:eyJhY3Rpdml0eUlkIjoiMTI1NTg5IiwiZXhwZXJpZW5jZUlkIjoiMCJ9", propositionMap.get("id"));
         Assert.assertEquals("myMbox", propositionMap.get("scope"));
         Assert.assertEquals(testDecisionScopesMap, propositionMap.get("scopeDetails"));
-        List<Map<String, Object>> itemsList = (List<Map<String, Object>>) propositionMap.get("items");
+        final List<Map<String, Object>> itemsList = (List<Map<String, Object>>) propositionMap.get("items");
         Assert.assertNotNull(itemsList);
         Assert.assertEquals(1, itemsList.size());
         Assert.assertEquals("246315", itemsList.get(0).get("id"));

--- a/code/optimize/src/androidTest/java/com/adobe/marketing/mobile/optimize/OptimizeFunctionalTests.java
+++ b/code/optimize/src/androidTest/java/com/adobe/marketing/mobile/optimize/OptimizeFunctionalTests.java
@@ -939,8 +939,14 @@ public class OptimizeFunctionalTests {
         Map<String, Object> xdm = (Map<String, Object>) edgeRequestEventList.get(0).getEventData().get("xdm");
         Assert.assertEquals("decisioning.propositionDisplay", xdm.get("eventType"));
 
-        List<Map<String, Object>> propositionList = (List<Map<String, Object>>) ((Map<String, Object>) ((Map<String, Object>) xdm.get("_experience")).get("decisioning"))
-                .get("propositions");
+        Map<String, Object> experience =  (Map<String, Object>)xdm.get("_experience");
+        assertNotNull(experience);
+        Map<String, Object> decisioning =  (Map<String, Object>)experience.get("decisioning");
+        assertNotNull(decisioning);
+        Map<String, Object> propositionEventType = (Map<String, Object>)decisioning.get("propositionEventType");
+        assertNotNull(propositionEventType);
+        assertEquals(1, propositionEventType.get("display"));
+        List<Map<String, Object>> propositionList = (List<Map<String, Object>>)decisioning.get("propositions");
         Assert.assertNotNull(propositionList);
         Assert.assertEquals(1, propositionList.size());
         Map<String, Object> propositionData = propositionList.get(0);
@@ -1007,8 +1013,14 @@ public class OptimizeFunctionalTests {
         Map<String, Object> xdm = (Map<String, Object>) edgeRequestEventList.get(0).getEventData().get("xdm");
         Assert.assertEquals("decisioning.propositionInteract", xdm.get("eventType"));
 
-        List<Map<String, Object>> propositionList = (List<Map<String, Object>>) ((Map<String, Object>) ((Map<String, Object>) xdm.get("_experience")).get("decisioning"))
-                .get("propositions");
+        Map<String, Object> experience =  (Map<String, Object>)xdm.get("_experience");
+        assertNotNull(experience);
+        Map<String, Object> decisioning =  (Map<String, Object>)experience.get("decisioning");
+        assertNotNull(decisioning);
+        Map<String, Object> propositionEventType = (Map<String, Object>)decisioning.get("propositionEventType");
+        assertNotNull(propositionEventType);
+        assertEquals(1, propositionEventType.get("interact"));
+        List<Map<String, Object>> propositionList = (List<Map<String, Object>>)decisioning.get("propositions");
         Assert.assertNotNull(propositionList);
         Assert.assertEquals(1, propositionList.size());
         Map<String, Object> propositionData = propositionList.get(0);
@@ -1075,8 +1087,14 @@ public class OptimizeFunctionalTests {
         Map<String, Object> xdm = (Map<String, Object>) edgeRequestEventList.get(0).getEventData().get("xdm");
         Assert.assertEquals("decisioning.propositionInteract", xdm.get("eventType"));
 
-        List<Map<String, Object>> propositionList = (List<Map<String, Object>>) ((Map<String, Object>) ((Map<String, Object>) xdm.get("_experience")).get("decisioning"))
-                .get("propositions");
+        Map<String, Object> experience =  (Map<String, Object>)xdm.get("_experience");
+        assertNotNull(experience);
+        Map<String, Object> decisioning =  (Map<String, Object>)experience.get("decisioning");
+        assertNotNull(decisioning);
+        Map<String, Object> propositionEventType = (Map<String, Object>)decisioning.get("propositionEventType");
+        assertNotNull(propositionEventType);
+        assertEquals(1, propositionEventType.get("interact"));
+        List<Map<String, Object>> propositionList = (List<Map<String, Object>>)decisioning.get("propositions");
         Assert.assertNotNull(propositionList);
         Assert.assertEquals(1, propositionList.size());
         Map<String, Object> propositionData = propositionList.get(0);
@@ -1363,6 +1381,9 @@ public class OptimizeFunctionalTests {
         assertNotNull(experience);
         final Map<String, Object> decisioning = (Map<String, Object>)experience.get("decisioning");
         assertNotNull(decisioning);
+        final Map<String, Object> propositionEventType = (Map<String, Object>)decisioning.get("propositionEventType");
+        assertNotNull(propositionEventType);
+        assertEquals(1, propositionEventType.get("display"));
         final List<Map<String, Object>> propositionInteractionDetailsList = (List<Map<String, Object>>)decisioning.get("propositions");
         assertNotNull(propositionInteractionDetailsList);
         assertEquals(1, propositionInteractionDetailsList.size());
@@ -1432,6 +1453,9 @@ public class OptimizeFunctionalTests {
         assertNotNull(experience);
         final Map<String, Object> decisioning = (Map<String, Object>)experience.get("decisioning");
         assertNotNull(decisioning);
+        final Map<String, Object> propositionEventType = (Map<String, Object>)decisioning.get("propositionEventType");
+        assertNotNull(propositionEventType);
+        assertEquals(1, propositionEventType.get("interact"));
         final List<Map<String, Object>> propositionInteractionDetailsList = (List<Map<String, Object>>)decisioning.get("propositions");
         assertNotNull(propositionInteractionDetailsList);
         assertEquals(1, propositionInteractionDetailsList.size());

--- a/code/optimize/src/androidTest/java/com/adobe/marketing/mobile/optimize/OptimizeFunctionalTests.java
+++ b/code/optimize/src/androidTest/java/com/adobe/marketing/mobile/optimize/OptimizeFunctionalTests.java
@@ -928,36 +928,36 @@ public class OptimizeFunctionalTests {
         offer.displayed();
 
         //Assert
-        List<Event> optimizeRequestEventsList = TestHelper.getDispatchedEventsWith(OptimizeTestConstants.EventType.OPTIMIZE, OptimizeTestConstants.EventSource.REQUEST_CONTENT, 1000);
-        List<Event> edgeRequestEventList = TestHelper.getDispatchedEventsWith(OptimizeTestConstants.EventType.EDGE, OptimizeTestConstants.EventSource.REQUEST_CONTENT, 1000);
+        final List<Event> optimizeRequestEventsList = TestHelper.getDispatchedEventsWith(OptimizeTestConstants.EventType.OPTIMIZE, OptimizeTestConstants.EventSource.REQUEST_CONTENT, 1000);
+        final List<Event> edgeRequestEventList = TestHelper.getDispatchedEventsWith(OptimizeTestConstants.EventType.EDGE, OptimizeTestConstants.EventSource.REQUEST_CONTENT, 1000);
 
         Assert.assertNotNull(optimizeRequestEventsList);
         Assert.assertEquals(1, optimizeRequestEventsList.size());
         Assert.assertNotNull(edgeRequestEventList);
         Assert.assertEquals(1, edgeRequestEventList.size());
 
-        Map<String, Object> xdm = (Map<String, Object>) edgeRequestEventList.get(0).getEventData().get("xdm");
+        final Map<String, Object> xdm = (Map<String, Object>) edgeRequestEventList.get(0).getEventData().get("xdm");
         Assert.assertEquals("decisioning.propositionDisplay", xdm.get("eventType"));
 
-        Map<String, Object> experience =  (Map<String, Object>)xdm.get("_experience");
+        final Map<String, Object> experience =  (Map<String, Object>)xdm.get("_experience");
         assertNotNull(experience);
-        Map<String, Object> decisioning =  (Map<String, Object>)experience.get("decisioning");
+        final Map<String, Object> decisioning =  (Map<String, Object>)experience.get("decisioning");
         assertNotNull(decisioning);
-        Map<String, Object> propositionEventType = (Map<String, Object>)decisioning.get("propositionEventType");
+        final Map<String, Object> propositionEventType = (Map<String, Object>)decisioning.get("propositionEventType");
         assertNotNull(propositionEventType);
         assertEquals(1, propositionEventType.get("display"));
-        List<Map<String, Object>> propositionList = (List<Map<String, Object>>)decisioning.get("propositions");
+        final List<Map<String, Object>> propositionList = (List<Map<String, Object>>)decisioning.get("propositions");
         Assert.assertNotNull(propositionList);
         Assert.assertEquals(1, propositionList.size());
         Map<String, Object> propositionData = propositionList.get(0);
-        List<Map<String, Object>> propositionsList = (List<Map<String, Object>>) propositionData.get("propositions");
+        final List<Map<String, Object>> propositionsList = (List<Map<String, Object>>) propositionData.get("propositions");
         Assert.assertNotNull(propositionList);
         Assert.assertEquals(1, propositionList.size());
-        Map<String, Object> propositionMap = propositionList.get(0);
+        final Map<String, Object> propositionMap = propositionList.get(0);
         Assert.assertEquals("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", propositionMap.get("id"));
         Assert.assertEquals("eyJhY3Rpdml0eUlkIjoieGNvcmU6b2ZmZXItYWN0aXZpdHk6MTExMTExMTExMTExMTExMSIsInBsYWNlbWVudElkIjoieGNvcmU6b2ZmZXItcGxhY2VtZW50OjExMTExMTExMTExMTExMTEifQ==", propositionMap.get("scope"));
         Assert.assertTrue(((Map<String, Object>) propositionMap.get("scopeDetails")).isEmpty());
-        List<Map<String, Object>> itemsList = (List<Map<String, Object>>) propositionMap.get("items");
+        final List<Map<String, Object>> itemsList = (List<Map<String, Object>>) propositionMap.get("items");
         Assert.assertNotNull(itemsList);
         Assert.assertEquals(1, itemsList.size());
         Assert.assertEquals("xcore:personalized-offer:1111111111111111", itemsList.get(0).get("id"));
@@ -986,7 +986,7 @@ public class OptimizeFunctionalTests {
                 "            ]\n" +
                 "        }\n";
         ObjectMapper objectMapper = new ObjectMapper();
-        Map<String, Object> testDecisionScopesMap = objectMapper.readValue(testScopeDetails, new TypeReference<Map<String, Object>>() {});
+        final Map<String, Object> testDecisionScopesMap = objectMapper.readValue(testScopeDetails, new TypeReference<Map<String, Object>>() {});
 
         Offer offer = new Offer.Builder("246315", OfferType.TEXT, "Text Offer!!").build();
         //Set the proposition soft reference to Offer
@@ -1002,36 +1002,36 @@ public class OptimizeFunctionalTests {
         offer.tapped();
 
         //Assert
-        List<Event> optimizeRequestEventsList = TestHelper.getDispatchedEventsWith(OptimizeTestConstants.EventType.OPTIMIZE, OptimizeTestConstants.EventSource.REQUEST_CONTENT, 1000);
-        List<Event> edgeRequestEventList = TestHelper.getDispatchedEventsWith(OptimizeTestConstants.EventType.EDGE, OptimizeTestConstants.EventSource.REQUEST_CONTENT, 1000);
+        final List<Event> optimizeRequestEventsList = TestHelper.getDispatchedEventsWith(OptimizeTestConstants.EventType.OPTIMIZE, OptimizeTestConstants.EventSource.REQUEST_CONTENT, 1000);
+        final List<Event> edgeRequestEventList = TestHelper.getDispatchedEventsWith(OptimizeTestConstants.EventType.EDGE, OptimizeTestConstants.EventSource.REQUEST_CONTENT, 1000);
 
         Assert.assertNotNull(optimizeRequestEventsList);
         Assert.assertEquals(1, optimizeRequestEventsList.size());
         Assert.assertNotNull(edgeRequestEventList);
         Assert.assertEquals(1, edgeRequestEventList.size());
 
-        Map<String, Object> xdm = (Map<String, Object>) edgeRequestEventList.get(0).getEventData().get("xdm");
+        final Map<String, Object> xdm = (Map<String, Object>) edgeRequestEventList.get(0).getEventData().get("xdm");
         Assert.assertEquals("decisioning.propositionInteract", xdm.get("eventType"));
 
-        Map<String, Object> experience =  (Map<String, Object>)xdm.get("_experience");
+        final Map<String, Object> experience =  (Map<String, Object>)xdm.get("_experience");
         assertNotNull(experience);
-        Map<String, Object> decisioning =  (Map<String, Object>)experience.get("decisioning");
+        final Map<String, Object> decisioning =  (Map<String, Object>)experience.get("decisioning");
         assertNotNull(decisioning);
-        Map<String, Object> propositionEventType = (Map<String, Object>)decisioning.get("propositionEventType");
+        final Map<String, Object> propositionEventType = (Map<String, Object>)decisioning.get("propositionEventType");
         assertNotNull(propositionEventType);
         assertEquals(1, propositionEventType.get("interact"));
-        List<Map<String, Object>> propositionList = (List<Map<String, Object>>)decisioning.get("propositions");
+        final List<Map<String, Object>> propositionList = (List<Map<String, Object>>)decisioning.get("propositions");
         Assert.assertNotNull(propositionList);
         Assert.assertEquals(1, propositionList.size());
-        Map<String, Object> propositionData = propositionList.get(0);
+        final Map<String, Object> propositionData = propositionList.get(0);
         List<Map<String, Object>> propositionsList = (List<Map<String, Object>>) propositionData.get("propositions");
         Assert.assertNotNull(propositionList);
         Assert.assertEquals(1, propositionList.size());
-        Map<String, Object> propositionMap = propositionList.get(0);
+        final Map<String, Object> propositionMap = propositionList.get(0);
         Assert.assertEquals("AT:eyJhY3Rpdml0eUlkIjoiMTI1NTg5IiwiZXhwZXJpZW5jZUlkIjoiMCJ9", propositionMap.get("id"));
         Assert.assertEquals("myMbox", propositionMap.get("scope"));
         Assert.assertEquals(testDecisionScopesMap, propositionMap.get("scopeDetails"));
-        List<Map<String, Object>> itemsList = (List<Map<String, Object>>) propositionMap.get("items");
+        final List<Map<String, Object>> itemsList = (List<Map<String, Object>>) propositionMap.get("items");
         Assert.assertNotNull(itemsList);
         Assert.assertEquals(1, itemsList.size());
         Assert.assertEquals("246315", itemsList.get(0).get("id"));
@@ -1469,9 +1469,6 @@ public class OptimizeFunctionalTests {
         assertNotNull(items);
         assertEquals(1, items.size());
         assertEquals("246315", items.get(0).get("id"));
-
-
-
     }
 
     //18

--- a/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/Offer.java
+++ b/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/Offer.java
@@ -354,7 +354,15 @@ public class Offer {
         final List<Map<String, Object>> decisioningPropositions = new ArrayList<>();
         decisioningPropositions.add(propositionsData);
 
+        final Map<String, Object> propositionEventType = new HashMap<>();
+        if (experienceEventType.equals(OptimizeConstants.JsonValues.EE_EVENT_TYPE_PROPOSITION_DISPLAY)) {
+            propositionEventType.put(OptimizeConstants.JsonKeys.PROPOSITION_EVENT_TYPE_DISPLAY, 1);
+        } else {
+            propositionEventType.put(OptimizeConstants.JsonKeys.PROPOSITION_EVENT_TYPE_INTERACT, 1);
+        }
+
         final Map<String, Object> experienceDecisioning = new HashMap<>();
+        experienceDecisioning.put(OptimizeConstants.JsonKeys.DECISIONING_PROPOSITION_EVENT_TYPE, propositionEventType);
         experienceDecisioning.put(OptimizeConstants.JsonKeys.DECISIONING_PROPOSITIONS, decisioningPropositions);
 
         final Map<String, Object> experience = new HashMap<>();

--- a/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/Offer.java
+++ b/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/Offer.java
@@ -355,11 +355,10 @@ public class Offer {
         decisioningPropositions.add(propositionsData);
 
         final Map<String, Object> propositionEventType = new HashMap<>();
-        if (experienceEventType.equals(OptimizeConstants.JsonValues.EE_EVENT_TYPE_PROPOSITION_DISPLAY)) {
-            propositionEventType.put(OptimizeConstants.JsonKeys.PROPOSITION_EVENT_TYPE_DISPLAY, 1);
-        } else {
-            propositionEventType.put(OptimizeConstants.JsonKeys.PROPOSITION_EVENT_TYPE_INTERACT, 1);
-        }
+        final String propEventType = experienceEventType.equals(OptimizeConstants.JsonValues.EE_EVENT_TYPE_PROPOSITION_DISPLAY) ?
+                OptimizeConstants.JsonKeys.PROPOSITION_EVENT_TYPE_DISPLAY :
+                OptimizeConstants.JsonKeys.PROPOSITION_EVENT_TYPE_INTERACT;
+        propositionEventType.put(propEventType, 1);
 
         final Map<String, Object> experienceDecisioning = new HashMap<>();
         experienceDecisioning.put(OptimizeConstants.JsonKeys.DECISIONING_PROPOSITION_EVENT_TYPE, propositionEventType);

--- a/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/OptimizeConstants.java
+++ b/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/OptimizeConstants.java
@@ -133,6 +133,9 @@ class OptimizeConstants {
         static final String EXPERIENCE = "_experience";
         static final String EXPERIENCE_DECISIONING = "decisioning";
         static final String DECISIONING_PROPOSITION_ID = "propositionID";
+        static final String DECISIONING_PROPOSITION_EVENT_TYPE = "propositionEventType";
+        static final String PROPOSITION_EVENT_TYPE_DISPLAY = "display";
+        static final String PROPOSITION_EVENT_TYPE_INTERACT = "interact";
         static final String DECISIONING_PROPOSITIONS = "propositions";
         static final String DECISIONING_PROPOSITIONS_ID = "id";
         static final String DECISIONING_PROPOSITIONS_SCOPE = "scope";

--- a/code/optimize/src/test/java/com/adobe/marketing/mobile/optimize/OfferTests.java
+++ b/code/optimize/src/test/java/com/adobe/marketing/mobile/optimize/OfferTests.java
@@ -296,6 +296,9 @@ public class OfferTests {
         assertNotNull(experience);
         final Map<String, Object> decisioning = (Map<String, Object>)experience.get("decisioning");
         assertNotNull(decisioning);
+        final Map<String, Object> propositionEventType = (Map<String, Object>)decisioning.get("propositionEventType");
+        assertNotNull(propositionEventType);
+        assertEquals(1, propositionEventType.get("display"));
         final List<Map<String, Object>> propositionInteractionDetailsList = (List<Map<String, Object>>)decisioning.get("propositions");
         assertNotNull(propositionInteractionDetailsList);
         assertEquals(1, propositionInteractionDetailsList.size());
@@ -332,6 +335,9 @@ public class OfferTests {
         assertNotNull(experience);
         final Map<String, Object> decisioning = (Map<String, Object>)experience.get("decisioning");
         assertNotNull(decisioning);
+        final Map<String, Object> propositionEventType = (Map<String, Object>)decisioning.get("propositionEventType");
+        assertNotNull(propositionEventType);
+        assertEquals(1, propositionEventType.get("display"));
         final List<Map<String, Object>> propositionInteractionDetailsList = (List<Map<String, Object>>)decisioning.get("propositions");
         assertNotNull(propositionInteractionDetailsList);
         assertEquals(1, propositionInteractionDetailsList.size());
@@ -397,6 +403,9 @@ public class OfferTests {
         assertNotNull(experience);
         final Map<String, Object> decisioning = (Map<String, Object>)experience.get("decisioning");
         assertNotNull(decisioning);
+        final Map<String, Object> propositionEventType = (Map<String, Object>)decisioning.get("propositionEventType");
+        assertNotNull(propositionEventType);
+        assertEquals(1, propositionEventType.get("interact"));
         final List<Map<String, Object>> propositionInteractionDetailsList = (List<Map<String, Object>>)decisioning.get("propositions");
         assertNotNull(propositionInteractionDetailsList);
         assertEquals(1, propositionInteractionDetailsList.size());
@@ -433,6 +442,9 @@ public class OfferTests {
         assertNotNull(experience);
         final Map<String, Object> decisioning = (Map<String, Object>)experience.get("decisioning");
         assertNotNull(decisioning);
+        final Map<String, Object> propositionEventType = (Map<String, Object>)decisioning.get("propositionEventType");
+        assertNotNull(propositionEventType);
+        assertEquals(1, propositionEventType.get("interact"));
         final List<Map<String, Object>> propositionInteractionDetailsList = (List<Map<String, Object>>)decisioning.get("propositions");
         assertNotNull(propositionInteractionDetailsList);
         assertEquals(1, propositionInteractionDetailsList.size());
@@ -509,6 +521,9 @@ public class OfferTests {
         assertNotNull(experience);
         final Map<String, Object> decisioning = (Map<String, Object>)experience.get("decisioning");
         assertNotNull(decisioning);
+        final Map<String, Object> propositionEventType = (Map<String, Object>)decisioning.get("propositionEventType");
+        assertNotNull(propositionEventType);
+        assertEquals(1, propositionEventType.get("display"));
         final List<Map<String, Object>> propositionInteractionDetailsList = (List<Map<String, Object>>)decisioning.get("propositions");
         assertNotNull(propositionInteractionDetailsList);
         assertEquals(1, propositionInteractionDetailsList.size());
@@ -556,6 +571,9 @@ public class OfferTests {
         assertNotNull(experience);
         final Map<String, Object> decisioning = (Map<String, Object>)experience.get("decisioning");
         assertNotNull(decisioning);
+        final Map<String, Object> propositionEventType = (Map<String, Object>)decisioning.get("propositionEventType");
+        assertNotNull(propositionEventType);
+        assertEquals(1, propositionEventType.get("display"));
         final List<Map<String, Object>> propositionInteractionDetailsList = (List<Map<String, Object>>)decisioning.get("propositions");
         assertNotNull(propositionInteractionDetailsList);
         assertEquals(1, propositionInteractionDetailsList.size());
@@ -633,6 +651,9 @@ public class OfferTests {
         assertNotNull(experience);
         final Map<String, Object> decisioning = (Map<String, Object>)experience.get("decisioning");
         assertNotNull(decisioning);
+        final Map<String, Object> propositionEventType = (Map<String, Object>)decisioning.get("propositionEventType");
+        assertNotNull(propositionEventType);
+        assertEquals(1, propositionEventType.get("interact"));
         final List<Map<String, Object>> propositionInteractionDetailsList = (List<Map<String, Object>>)decisioning.get("propositions");
         assertNotNull(propositionInteractionDetailsList);
         assertEquals(1, propositionInteractionDetailsList.size());
@@ -680,6 +701,9 @@ public class OfferTests {
         assertNotNull(experience);
         final Map<String, Object> decisioning = (Map<String, Object>)experience.get("decisioning");
         assertNotNull(decisioning);
+        final Map<String, Object> propositionEventType = (Map<String, Object>)decisioning.get("propositionEventType");
+        assertNotNull(propositionEventType);
+        assertEquals(1, propositionEventType.get("interact"));
         final List<Map<String, Object>> propositionInteractionDetailsList = (List<Map<String, Object>>)decisioning.get("propositions");
         assertNotNull(propositionInteractionDetailsList);
         assertEquals(1, propositionInteractionDetailsList.size());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
```
When sending a decisioning.propositionDisplay event, set _experience.decisioning.propositionEventType.display=1.
When sending a decisioning.propositionInteract event, set _experience.decisioning.propositionEventType.interact=1.
```
Updated unit, functional tests.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
