### PR TITLE
Verify configuration shared state is set before processing update proposition requests

### DIFF
--- a/code/app/build.gradle
+++ b/code/app/build.gradle
@@ -70,10 +70,10 @@ dependencies {
 
     // Adobe mobile SDKs
     implementation project(":optimize")
-    implementation 'com.adobe.marketing.mobile:core:2.0.0'
-    implementation 'com.adobe.marketing.mobile:lifecycle:2.0.0'
-    implementation 'com.adobe.marketing.mobile:signal:2.0.0'
-    implementation 'com.adobe.marketing.mobile:assurance:2.0.0'
+    implementation 'com.adobe.marketing.mobile:core:2.3.0'
+    implementation 'com.adobe.marketing.mobile:lifecycle:2.0.4'
+    implementation 'com.adobe.marketing.mobile:signal:2.0.1'
+    implementation 'com.adobe.marketing.mobile:assurance:2.1.1'
     implementation 'com.adobe.marketing.mobile:edge:2.0.0'
-    implementation 'com.adobe.marketing.mobile:edgeidentity:2.0.0'
+    implementation 'com.adobe.marketing.mobile:edgeidentity:2.0.1'
 }

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -16,7 +16,7 @@ android.useAndroidX=true
 moduleProjectName=optimize
 moduleName=optimize
 moduleAARName=optimize-phone-release.aar
-moduleVersion=2.0.0
+moduleVersion=2.0.1
 
 mavenRepoName=AdobeMobileOptimizeSdk
 mavenRepoDescription=Adobe Experience Platform Optimize extension for the Adobe Experience Platform Mobile SDK

--- a/code/optimize/src/androidTest/java/com/adobe/marketing/mobile/optimize/OptimizeTestConstants.java
+++ b/code/optimize/src/androidTest/java/com/adobe/marketing/mobile/optimize/OptimizeTestConstants.java
@@ -14,7 +14,7 @@ package com.adobe.marketing.mobile.optimize;
 
 public class OptimizeTestConstants {
 
-    static final String EXTENSION_VERSION = "2.0.0";
+    static final String EXTENSION_VERSION = "2.0.1";
     public static final String LOG_TAG = "OptimizeTest";
     static final String CONFIG_DATA_STORE = "AdobeMobile_ConfigState";
 

--- a/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/OptimizeConstants.java
+++ b/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/OptimizeConstants.java
@@ -14,7 +14,7 @@ package com.adobe.marketing.mobile.optimize;
 
 class OptimizeConstants {
     static final String LOG_TAG = "Optimize";
-    static final String EXTENSION_VERSION = "2.0.0";
+    static final String EXTENSION_VERSION = "2.0.1";
     static final String EXTENSION_NAME = "com.adobe.optimize";
     static final String FRIENDLY_NAME = "Optimize";
     static final long DEFAULT_RESPONSE_CALLBACK_TIMEOUT = 500L;

--- a/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/OptimizeExtension.java
+++ b/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/OptimizeExtension.java
@@ -93,7 +93,7 @@ class OptimizeExtension extends Extension {
         if (OptimizeConstants.EventType.OPTIMIZE.equalsIgnoreCase(event.getType())
                 && OptimizeConstants.EventSource.REQUEST_CONTENT.equalsIgnoreCase(event.getSource())) {
             SharedStateResult configurationSharedState = getApi().getSharedState(OptimizeConstants.Configuration.EXTENSION_NAME, event, false, SharedStateResolution.ANY);
-            return configurationSharedState != null && configurationSharedState.getValue() != null;
+            return configurationSharedState != null && configurationSharedState.getStatus() == SharedStateStatus.SET;
         }
         return true;
     }
@@ -461,8 +461,7 @@ class OptimizeExtension extends Extension {
                 event,
                 false,
                 SharedStateResolution.ANY);
-        return configurationSharedState != null && configurationSharedState.getStatus() != SharedStateStatus.PENDING ?
-                configurationSharedState.getValue() : null;
+        return configurationSharedState != null ? configurationSharedState.getValue() : null;
     }
 
     /**

--- a/code/optimize/src/test/java/com/adobe/marketing/mobile/optimize/OptimizeExtensionTests.java
+++ b/code/optimize/src/test/java/com/adobe/marketing/mobile/optimize/OptimizeExtensionTests.java
@@ -66,7 +66,7 @@ public class OptimizeExtensionTests {
     public void test_getVersion() {
         // test
         final String extensionVersion = extension.getVersion();
-        Assert.assertEquals("getVersion should return the correct extension version.", "2.0.0", extensionVersion);
+        Assert.assertEquals("getVersion should return the correct extension version.", "2.0.1", extensionVersion);
     }
 
     @Test
@@ -104,7 +104,7 @@ public class OptimizeExtensionTests {
     @Test
     public void testReadyForEvent_configurationSet() {
         // setup
-        setConfigurationSharedState(new HashMap<String, Object>() {
+        setConfigurationSharedState(SharedStateStatus.SET, new HashMap<String, Object>() {
             {
                 put("edge.configId", "ffffffff-ffff-ffff-ffff-ffffffffffff");
             }
@@ -117,8 +117,14 @@ public class OptimizeExtensionTests {
     }
 
     @Test
-    public void testReadyForEvent_configurationNotSet() {
+    public void testReadyForEvent_configurationPending() {
         // setup
+        setConfigurationSharedState(SharedStateStatus.PENDING, new HashMap<String, Object>() {
+            {
+                put("edge.configId", "ffffffff-ffff-ffff-ffff-ffffffffffff");
+            }
+        });
+
         final Event testEvent = new Event.Builder("Optimize Update Propositions Request", "com.adobe.eventType.optimize", "com.adobe.eventSource.requestContent")
                 .build();
 
@@ -126,9 +132,19 @@ public class OptimizeExtensionTests {
     }
 
     @Test
-    public void testReadyForEvent_invalidConfigurationSet() {
+    public void testReadyForEvent_configurationPendingNoData() {
         // setup
-        setConfigurationSharedState(null);
+        setConfigurationSharedState(SharedStateStatus.PENDING, null);
+
+        final Event testEvent = new Event.Builder("Optimize Update Propositions Request", "com.adobe.eventType.optimize", "com.adobe.eventSource.requestContent")
+                .build();
+
+        Assert.assertFalse(extension.readyForEvent(testEvent));
+    }
+
+    @Test
+    public void testReadyForEvent_configurationNotSet() {
+        // setup
         final Event testEvent = new Event.Builder("Optimize Update Propositions Request", "com.adobe.eventType.optimize", "com.adobe.eventSource.requestContent")
                 .build();
 
@@ -156,7 +172,7 @@ public class OptimizeExtensionTests {
     @Test
     public void testHandleOptimizeRequestContent_nullEventData() {
         // setup
-        setConfigurationSharedState(new HashMap<String, Object>() {
+        setConfigurationSharedState(SharedStateStatus.SET, new HashMap<String, Object>() {
             {
                 put("edge.configId", "ffffffff-ffff-ffff-ffff-ffffffffffff");
             }
@@ -178,7 +194,7 @@ public class OptimizeExtensionTests {
     @Test
     public void testHandleOptimizeRequestContent_emptyEventData() {
         // setup
-        setConfigurationSharedState(new HashMap<String, Object>() {
+        setConfigurationSharedState(SharedStateStatus.SET, new HashMap<String, Object>() {
             {
                 put("edge.configId", "ffffffff-ffff-ffff-ffff-ffffffffffff");
             }
@@ -199,7 +215,7 @@ public class OptimizeExtensionTests {
     @Test
     public void testHandleOptimizeRequestContent_invalidRequestType() {
         // setup
-        setConfigurationSharedState(new HashMap<String, Object>() {
+        setConfigurationSharedState(SharedStateStatus.SET, new HashMap<String, Object>() {
             {
                 put("edge.configId", "ffffffff-ffff-ffff-ffff-ffffffffffff");
             }
@@ -230,7 +246,7 @@ public class OptimizeExtensionTests {
                     .thenAnswer((Answer<byte[]>) invocation -> java.util.Base64.getDecoder().decode((String) invocation.getArguments()[0]));
 
             // setup
-            setConfigurationSharedState(new HashMap<String, Object>() {
+            setConfigurationSharedState(SharedStateStatus.SET, new HashMap<String, Object>() {
                 {
                     put("edge.configId", "ffffffff-ffff-ffff-ffff-ffffffffffff");
                 }
@@ -294,7 +310,7 @@ public class OptimizeExtensionTests {
                     .thenAnswer((Answer<byte[]>) invocation -> java.util.Base64.getDecoder().decode((String) invocation.getArguments()[0]));
 
             // setup
-            setConfigurationSharedState(new HashMap<String, Object>() {
+            setConfigurationSharedState(SharedStateStatus.SET, new HashMap<String, Object>() {
                 {
                     put("edge.configId", "ffffffff-ffff-ffff-ffff-ffffffffffff");
                     put("optimize.datasetId", "111111111111111111111111");
@@ -371,7 +387,7 @@ public class OptimizeExtensionTests {
                     .thenAnswer((Answer<byte[]>) invocation -> java.util.Base64.getDecoder().decode((String) invocation.getArguments()[0]));
 
             // setup
-            setConfigurationSharedState(new HashMap<String, Object>() {
+            setConfigurationSharedState(SharedStateStatus.SET, new HashMap<String, Object>() {
                 {
                     put("edge.configId", "ffffffff-ffff-ffff-ffff-ffffffffffff");
                 }
@@ -447,7 +463,7 @@ public class OptimizeExtensionTests {
                     .thenAnswer((Answer<byte[]>) invocation -> java.util.Base64.getDecoder().decode((String) invocation.getArguments()[0]));
 
             // setup
-            setConfigurationSharedState(new HashMap<String, Object>() {
+            setConfigurationSharedState(SharedStateStatus.SET, new HashMap<String, Object>() {
                 {
                     put("edge.configId", "ffffffff-ffff-ffff-ffff-ffffffffffff");
                 }
@@ -542,7 +558,7 @@ public class OptimizeExtensionTests {
                     .thenAnswer((Answer<byte[]>) invocation -> java.util.Base64.getDecoder().decode((String) invocation.getArguments()[0]));
 
             // setup
-            setConfigurationSharedState(new HashMap<String, Object>() {
+            setConfigurationSharedState(SharedStateStatus.SET, new HashMap<String, Object>() {
                 {
                     put("edge.configId", "ffffffff-ffff-ffff-ffff-ffffffffffff");
                 }
@@ -573,7 +589,7 @@ public class OptimizeExtensionTests {
                     .thenAnswer((Answer<byte[]>) invocation -> java.util.Base64.getDecoder().decode((String) invocation.getArguments()[0]));
 
             // setup
-            setConfigurationSharedState(new HashMap<String, Object>() {
+            setConfigurationSharedState(SharedStateStatus.SET, new HashMap<String, Object>() {
                 {
                     put("edge.configId", "ffffffff-ffff-ffff-ffff-ffffffffffff");
                 }
@@ -609,7 +625,7 @@ public class OptimizeExtensionTests {
                     .thenAnswer((Answer<byte[]>) invocation -> java.util.Base64.getDecoder().decode((String) invocation.getArguments()[0]));
 
             // setup
-            setConfigurationSharedState(new HashMap<String, Object>() {
+            setConfigurationSharedState(SharedStateStatus.SET, new HashMap<String, Object>() {
                 {
                     put("edge.configId", "ffffffff-ffff-ffff-ffff-ffffffffffff");
                 }
@@ -978,7 +994,7 @@ public class OptimizeExtensionTests {
             base64MockedStatic.when(() -> Base64.decode(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt()))
                     .thenAnswer((Answer<byte[]>) invocation -> java.util.Base64.getDecoder().decode((String) invocation.getArguments()[0]));
             // setup
-            setConfigurationSharedState(new HashMap<String, Object>() {
+            setConfigurationSharedState(SharedStateStatus.SET, new HashMap<String, Object>() {
                 {
                     put("edge.configId", "ffffffff-ffff-ffff-ffff-ffffffffffff");
                 }
@@ -1047,7 +1063,7 @@ public class OptimizeExtensionTests {
             base64MockedStatic.when(() -> Base64.decode(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt()))
                     .thenAnswer((Answer<byte[]>) invocation -> java.util.Base64.getDecoder().decode((String) invocation.getArguments()[0]));
             // setup
-            setConfigurationSharedState(new HashMap<String, Object>() {
+            setConfigurationSharedState(SharedStateStatus.SET, new HashMap<String, Object>() {
                 {
                     put("edge.configId", "ffffffff-ffff-ffff-ffff-ffffffffffff");
                 }
@@ -1119,7 +1135,7 @@ public class OptimizeExtensionTests {
                     .thenAnswer((Answer<byte[]>) invocation -> java.util.Base64.getDecoder().decode((String) invocation.getArguments()[0]));
 
             // setup
-            setConfigurationSharedState(new HashMap<String, Object>() {
+            setConfigurationSharedState(SharedStateStatus.SET, new HashMap<String, Object>() {
                 {
                     put("edge.configId", "ffffffff-ffff-ffff-ffff-ffffffffffff");
                 }
@@ -1172,7 +1188,7 @@ public class OptimizeExtensionTests {
                     .thenAnswer((Answer<byte[]>) invocation -> java.util.Base64.getDecoder().decode((String) invocation.getArguments()[0]));
 
             // setup
-            setConfigurationSharedState(new HashMap<String, Object>() {
+            setConfigurationSharedState(SharedStateStatus.SET, new HashMap<String, Object>() {
                 {
                     put("edge.configId", "ffffffff-ffff-ffff-ffff-ffffffffffff");
                 }
@@ -1219,7 +1235,7 @@ public class OptimizeExtensionTests {
                     .thenAnswer((Answer<byte[]>) invocation -> java.util.Base64.getDecoder().decode((String) invocation.getArguments()[0]));
 
             // setup
-            setConfigurationSharedState(new HashMap<String, Object>() {
+            setConfigurationSharedState(SharedStateStatus.SET, new HashMap<String, Object>() {
                 {
                     put("edge.configId", "ffffffff-ffff-ffff-ffff-ffffffffffff");
                 }
@@ -1262,7 +1278,7 @@ public class OptimizeExtensionTests {
     @Test
     public void testHandleOptimizeRequestContent_HandleTrackPropositions_validPropositionInteractionsForDisplay() throws Exception{
         // setup
-        setConfigurationSharedState(new HashMap<String, Object>() {
+        setConfigurationSharedState(SharedStateStatus.SET, new HashMap<String, Object>() {
             {
                 put("edge.configId", "ffffffff-ffff-ffff-ffff-ffffffffffff");
             }
@@ -1311,7 +1327,7 @@ public class OptimizeExtensionTests {
     @Test
     public void testHandleOptimizeRequestContent_HandleTrackPropositions_validPropositionInteractionsForTap() throws Exception{
         // setup
-        setConfigurationSharedState(new HashMap<String, Object>() {
+        setConfigurationSharedState(SharedStateStatus.SET, new HashMap<String, Object>() {
             {
                 put("edge.configId", "ffffffff-ffff-ffff-ffff-ffffffffffff");
             }
@@ -1370,7 +1386,7 @@ public class OptimizeExtensionTests {
     @Test
     public void testHandleOptimizeRequestContent_HandleTrackPropositions_validPropositionInteractionsWithDatasetIdInConfig() throws Exception{
         // setup
-        setConfigurationSharedState(new HashMap<String, Object>() {
+        setConfigurationSharedState(SharedStateStatus.SET, new HashMap<String, Object>() {
             {
                 put("edge.configId", "ffffffff-ffff-ffff-ffff-ffffffffffff");
                 put("optimize.datasetId", "111111111111111111111111");
@@ -1452,7 +1468,7 @@ public class OptimizeExtensionTests {
     public void testHandleOptimizeRequestContent_HandleTrackPropositions_missingPropositionInteractions() throws Exception{
         try (MockedStatic<Log> logMockedStatic = Mockito.mockStatic(Log.class)) {
             // setup
-            setConfigurationSharedState(new HashMap<String, Object>() {
+            setConfigurationSharedState(SharedStateStatus.SET, new HashMap<String, Object>() {
                 {
                     put("edge.configId", "ffffffff-ffff-ffff-ffff-ffffffffffff");
                 }
@@ -1477,7 +1493,7 @@ public class OptimizeExtensionTests {
     public void testHandleOptimizeRequestContent_HandleTrackPropositions_emptyPropositionInteractions() throws Exception{
         try (MockedStatic<Log> logMockedStatic = Mockito.mockStatic(Log.class)) {
             // setup
-            setConfigurationSharedState(new HashMap<String, Object>() {
+            setConfigurationSharedState(SharedStateStatus.SET, new HashMap<String, Object>() {
                 {
                     put("edge.configId", "ffffffff-ffff-ffff-ffff-ffffffffffff");
                 }
@@ -1542,13 +1558,13 @@ public class OptimizeExtensionTests {
 
 
     // Helper methods
-    private void setConfigurationSharedState(final Map<String, Object> data) {
+    private void setConfigurationSharedState(final SharedStateStatus status, final Map<String, Object> data) {
         Mockito.when(mockExtensionApi.getSharedState(
                 ArgumentMatchers.eq(OptimizeConstants.Configuration.EXTENSION_NAME),
                 ArgumentMatchers.any(),
                 ArgumentMatchers.eq(false),
                 ArgumentMatchers.eq(SharedStateResolution.ANY)
-        )).thenReturn(new SharedStateResult(SharedStateStatus.SET, data));
+        )).thenReturn(new SharedStateResult(status, data));
     }
 }
 

--- a/code/optimize/src/test/java/com/adobe/marketing/mobile/optimize/OptimizeTests.java
+++ b/code/optimize/src/test/java/com/adobe/marketing/mobile/optimize/OptimizeTests.java
@@ -55,7 +55,7 @@ public class OptimizeTests {
     public void test_extensionVersion() {
         // test
         final String extensionVersion = Optimize.extensionVersion();
-        Assert.assertEquals("extensionVersion API should return the correct version string.", "2.0.0",
+        Assert.assertEquals("extensionVersion API should return the correct version string.", "2.0.1",
                 extensionVersion);
     }
 


### PR DESCRIPTION
* Verify configuration shared state is set before processing update proposition requests.

* Updated/ added tests

* Fixed failing functional test

* Fixed another failing test

* Ensure streaming listener is registered only once.

* Updates tests

* Fixed verbiage

* Revert "Ensure streaming listener is registered only once."

This reverts commit 5f24bfa98b7e0583b7d77b0afa231decf8c14224.

* Isolating fix to the dropping of first request

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
