### PR TITLE
Provide errors and propositions in updateProposition callback

### DIFF
--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -24,6 +24,6 @@ mavenRepoDescription=Adobe Experience Platform Optimize extension for the Adobe 
 mavenUploadDryRunFlag=false
 
 # production versions for production build
-mavenCoreVersion=3.0.0
+mavenCoreVersion=3.2.0
 mavenEdgeVersion=3.0.0
 functionalTestEdgeVersion=3.0.0

--- a/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/AEPOptimizeError.kt
+++ b/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/AEPOptimizeError.kt
@@ -22,6 +22,19 @@ import com.adobe.marketing.mobile.AdobeError
  * @param adobeError The corresponding AdobeError.
  */
 class AEPOptimizeError(val type: String? = "", val status: Int? = 0, val title: String? = "", val detail: String? = "", var report: Map<String, Any>?, var adobeError: AdobeError?) {
+
+    val serverErrors = listOf(
+        OptimizeConstants.HTTPResponseCodes.tooManyRequests,
+        OptimizeConstants.HTTPResponseCodes.internalServerError,
+        OptimizeConstants.HTTPResponseCodes.serviceUnavailable
+    )
+
+    val networkErrors = listOf(
+        OptimizeConstants.HTTPResponseCodes.badGateway,
+        OptimizeConstants.HTTPResponseCodes.gatewayTimeout
+    )
+
+
     companion object {
         fun getTimeoutError(): AEPOptimizeError {
             return AEPOptimizeError(

--- a/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/AEPOptimizeError.kt
+++ b/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/AEPOptimizeError.kt
@@ -51,13 +51,13 @@ data class AEPOptimizeError(
         const val ERROR_NAME = "errorName"
         const val ERROR_CODE = "errorCode"
 
-        val serverErrors = listOf(
+        private val serverErrors = listOf(
             OptimizeConstants.HTTPResponseCodes.tooManyRequests,
             OptimizeConstants.HTTPResponseCodes.internalServerError,
             OptimizeConstants.HTTPResponseCodes.serviceUnavailable
         )
 
-        val networkErrors = listOf(
+        private val networkErrors = listOf(
             OptimizeConstants.HTTPResponseCodes.badGateway,
             OptimizeConstants.HTTPResponseCodes.gatewayTimeout
         )

--- a/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/AEPOptimizeError.kt
+++ b/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/AEPOptimizeError.kt
@@ -32,13 +32,13 @@ data class AEPOptimizeError(
     var adobeError: AdobeError?
 ) {
 
-    fun toMap(): Map<String, Any?> = mapOf(
+    fun toEventData(): Map<String, Any?> = mapOf(
         TYPE to type,
         STATUS to status,
         TITLE to title,
         DETAIL to detail,
         REPORT to report,
-        ADOBE_ERROR to adobeError?.toMap()
+        ADOBE_ERROR to adobeError?.toEventData()
     )
 
     companion object {
@@ -62,7 +62,7 @@ data class AEPOptimizeError(
             OptimizeConstants.HTTPResponseCodes.gatewayTimeout
         )
 
-        fun AdobeError.toMap(): Map<String, Any?> = mapOf(
+        fun AdobeError.toEventData(): Map<String, Any?> = mapOf(
             ERROR_NAME to errorName,
             ERROR_CODE to errorCode,
         )

--- a/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/AEPOptimizeError.kt
+++ b/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/AEPOptimizeError.kt
@@ -32,17 +32,6 @@ data class AEPOptimizeError(
     var adobeError: AdobeError?
 ) {
 
-    val serverErrors = listOf(
-        OptimizeConstants.HTTPResponseCodes.tooManyRequests,
-        OptimizeConstants.HTTPResponseCodes.internalServerError,
-        OptimizeConstants.HTTPResponseCodes.serviceUnavailable
-    )
-
-    val networkErrors = listOf(
-        OptimizeConstants.HTTPResponseCodes.badGateway,
-        OptimizeConstants.HTTPResponseCodes.gatewayTimeout
-    )
-
     fun toMap(): Map<String, Any?> = mapOf(
         TYPE to type,
         STATUS to status,
@@ -61,6 +50,17 @@ data class AEPOptimizeError(
         const val ADOBE_ERROR = "adobeError"
         const val ERROR_NAME = "errorName"
         const val ERROR_CODE = "errorCode"
+
+        val serverErrors = listOf(
+            OptimizeConstants.HTTPResponseCodes.tooManyRequests,
+            OptimizeConstants.HTTPResponseCodes.internalServerError,
+            OptimizeConstants.HTTPResponseCodes.serviceUnavailable
+        )
+
+        val networkErrors = listOf(
+            OptimizeConstants.HTTPResponseCodes.badGateway,
+            OptimizeConstants.HTTPResponseCodes.gatewayTimeout
+        )
 
         fun AdobeError.toMap(): Map<String, Any?> = mapOf(
             ERROR_NAME to errorName,
@@ -106,11 +106,10 @@ data class AEPOptimizeError(
             )
         }
 
-        private fun getAdobeErrorFromStatus(status: Int?): AdobeError = when (status) {
-            408 -> AdobeError.CALLBACK_TIMEOUT
-            400, 403, 404 -> AdobeError.UNEXPECTED_ERROR
-            429, 500, 503 -> AdobeError.UNEXPECTED_ERROR
-            502, 504 -> AdobeError.UNEXPECTED_ERROR
+        private fun getAdobeErrorFromStatus(status: Int?): AdobeError = when {
+            status == OptimizeConstants.HTTPResponseCodes.clientTimeout -> AdobeError.CALLBACK_TIMEOUT
+            serverErrors.contains(status) -> AdobeError.UNEXPECTED_ERROR
+            serverErrors.contains(status) -> AdobeError.UNEXPECTED_ERROR
             else -> AdobeError.UNEXPECTED_ERROR
         }
     }

--- a/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/AEPOptimizeError.kt
+++ b/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/AEPOptimizeError.kt
@@ -108,8 +108,8 @@ data class AEPOptimizeError(
 
         private fun getAdobeErrorFromStatus(status: Int?): AdobeError = when {
             status == OptimizeConstants.HTTPResponseCodes.clientTimeout -> AdobeError.CALLBACK_TIMEOUT
-            serverErrors.contains(status) -> AdobeError.UNEXPECTED_ERROR
-            serverErrors.contains(status) -> AdobeError.UNEXPECTED_ERROR
+            serverErrors.contains(status) -> AdobeError.SERVER_ERROR
+            networkErrors.contains(status) -> AdobeError.NETWORK_ERROR
             else -> AdobeError.UNEXPECTED_ERROR
         }
     }

--- a/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/Optimize.java
+++ b/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/Optimize.java
@@ -182,25 +182,32 @@ public class Optimize {
                                 }
                             }
 
-
                             if (eventData.containsKey(
                                     OptimizeConstants.EventDataKeys.PROPOSITIONS)) {
-                                final Map<DecisionScope, OptimizeProposition> propositionsMap =
-                                        new HashMap<>();
-                                final Map<String, Object> propositionData =
-                                        DataReader.getTypedMap(
+
+                                final List<Map<String, Object>> propositionsList;
+                                propositionsList =
+                                        DataReader.getTypedListOfMap(
                                                 Object.class,
                                                 eventData,
                                                 OptimizeConstants.EventDataKeys.PROPOSITIONS);
-
-                                final OptimizeProposition optimizeProposition =
-                                        OptimizeProposition.fromEventData(propositionData);
-                                if (optimizeProposition != null
-                                        && !OptimizeUtils.isNullOrEmpty(
+                                final Map<DecisionScope, OptimizeProposition> propositionsMap =
+                                        new HashMap<>();
+                                if (propositionsList != null) {
+                                    for (final Map<String, Object> propositionData : propositionsList) {
+                                        final OptimizeProposition optimizeProposition =
+                                                OptimizeProposition.fromEventData(propositionData);
+                                        if (optimizeProposition != null
+                                                && !OptimizeUtils.isNullOrEmpty(
                                                 optimizeProposition.getScope())) {
-                                    final DecisionScope scope =
-                                            new DecisionScope(optimizeProposition.getScope());
-                                    propositionsMap.put(scope, optimizeProposition);
+                                            final DecisionScope scope =
+                                                    new DecisionScope(optimizeProposition.getScope());
+                                            propositionsMap.put(scope, optimizeProposition);
+                                        }
+                                    }
+                                }
+
+                                if (callback != null) {
                                     callback.call(propositionsMap);
                                 }
                             }

--- a/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/Optimize.java
+++ b/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/Optimize.java
@@ -12,6 +12,7 @@
 package com.adobe.marketing.mobile.optimize;
 
 import static com.adobe.marketing.mobile.optimize.AEPOptimizeError.toAEPOptimizeError;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.adobe.marketing.mobile.AdobeCallback;
@@ -176,9 +177,14 @@ public class Optimize {
 
                             if (eventData.containsKey(
                                     OptimizeConstants.EventDataKeys.RESPONSE_ERROR)) {
-                                Object error =  eventData.get(OptimizeConstants.EventDataKeys.RESPONSE_ERROR);
+                                Object error =
+                                        eventData.get(
+                                                OptimizeConstants.EventDataKeys.RESPONSE_ERROR);
                                 if (error instanceof Map) {
-                                    failWithOptimizeError(callback, toAEPOptimizeError((Map<String, ? extends Object>) error));
+                                    failWithOptimizeError(
+                                            callback,
+                                            toAEPOptimizeError(
+                                                    (Map<String, ? extends Object>) error));
                                 }
                             }
 
@@ -194,14 +200,16 @@ public class Optimize {
                                 final Map<DecisionScope, OptimizeProposition> propositionsMap =
                                         new HashMap<>();
                                 if (propositionsList != null) {
-                                    for (final Map<String, Object> propositionData : propositionsList) {
+                                    for (final Map<String, Object> propositionData :
+                                            propositionsList) {
                                         final OptimizeProposition optimizeProposition =
                                                 OptimizeProposition.fromEventData(propositionData);
                                         if (optimizeProposition != null
                                                 && !OptimizeUtils.isNullOrEmpty(
-                                                optimizeProposition.getScope())) {
+                                                        optimizeProposition.getScope())) {
                                             final DecisionScope scope =
-                                                    new DecisionScope(optimizeProposition.getScope());
+                                                    new DecisionScope(
+                                                            optimizeProposition.getScope());
                                             propositionsMap.put(scope, optimizeProposition);
                                         }
                                     }

--- a/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/Optimize.java
+++ b/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/Optimize.java
@@ -188,36 +188,35 @@ public class Optimize {
                                 }
                             }
 
-                            if (eventData.containsKey(
+                            if (!eventData.containsKey(
                                     OptimizeConstants.EventDataKeys.PROPOSITIONS)) {
+                                return;
+                            }
 
-                                final List<Map<String, Object>> propositionsList;
-                                propositionsList =
-                                        DataReader.getTypedListOfMap(
-                                                Object.class,
-                                                eventData,
-                                                OptimizeConstants.EventDataKeys.PROPOSITIONS);
-                                final Map<DecisionScope, OptimizeProposition> propositionsMap =
-                                        new HashMap<>();
-                                if (propositionsList != null) {
-                                    for (final Map<String, Object> propositionData :
-                                            propositionsList) {
-                                        final OptimizeProposition optimizeProposition =
-                                                OptimizeProposition.fromEventData(propositionData);
-                                        if (optimizeProposition != null
-                                                && !OptimizeUtils.isNullOrEmpty(
-                                                        optimizeProposition.getScope())) {
-                                            final DecisionScope scope =
-                                                    new DecisionScope(
-                                                            optimizeProposition.getScope());
-                                            propositionsMap.put(scope, optimizeProposition);
-                                        }
+                            final List<Map<String, Object>> propositionsList;
+                            propositionsList =
+                                    DataReader.getTypedListOfMap(
+                                            Object.class,
+                                            eventData,
+                                            OptimizeConstants.EventDataKeys.PROPOSITIONS);
+                            final Map<DecisionScope, OptimizeProposition> propositionsMap =
+                                    new HashMap<>();
+                            if (propositionsList != null) {
+                                for (final Map<String, Object> propositionData : propositionsList) {
+                                    final OptimizeProposition optimizeProposition =
+                                            OptimizeProposition.fromEventData(propositionData);
+                                    if (optimizeProposition != null
+                                            && !OptimizeUtils.isNullOrEmpty(
+                                                    optimizeProposition.getScope())) {
+                                        final DecisionScope scope =
+                                                new DecisionScope(optimizeProposition.getScope());
+                                        propositionsMap.put(scope, optimizeProposition);
                                     }
                                 }
+                            }
 
-                                if (callback != null) {
-                                    callback.call(propositionsMap);
-                                }
+                            if (callback != null) {
+                                callback.call(propositionsMap);
                             }
                         } catch (DataReaderException e) {
                             failWithOptimizeError(

--- a/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/Optimize.java
+++ b/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/Optimize.java
@@ -11,8 +11,6 @@
 
 package com.adobe.marketing.mobile.optimize;
 
-import static com.adobe.marketing.mobile.optimize.AEPOptimizeError.toAEPOptimizeError;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.adobe.marketing.mobile.AdobeCallback;
@@ -183,7 +181,7 @@ public class Optimize {
                                 if (error instanceof Map) {
                                     failWithOptimizeError(
                                             callback,
-                                            toAEPOptimizeError(
+                                            AEPOptimizeError.toAEPOptimizeError(
                                                     (Map<String, ? extends Object>) error));
                                 }
                             }

--- a/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/Optimize.java
+++ b/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/Optimize.java
@@ -174,6 +174,15 @@ public class Optimize {
                             }
 
                             if (eventData.containsKey(
+                                    OptimizeConstants.EventDataKeys.RESPONSE_ERROR)) {
+                                Object error =  eventData.get(OptimizeConstants.EventDataKeys.RESPONSE_ERROR);
+                                if (error instanceof AEPOptimizeError) {
+                                    failWithOptimizeError(callback, (AEPOptimizeError) error);
+                                }
+                            }
+
+
+                            if (eventData.containsKey(
                                     OptimizeConstants.EventDataKeys.PROPOSITIONS)) {
                                 final Map<DecisionScope, OptimizeProposition> propositionsMap =
                                         new HashMap<>();
@@ -191,8 +200,8 @@ public class Optimize {
                                     final DecisionScope scope =
                                             new DecisionScope(optimizeProposition.getScope());
                                     propositionsMap.put(scope, optimizeProposition);
+                                    callback.call(propositionsMap);
                                 }
-                                callback.call(propositionsMap);
                             }
                         } catch (DataReaderException e) {
                             failWithOptimizeError(

--- a/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/Optimize.java
+++ b/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/Optimize.java
@@ -11,6 +11,7 @@
 
 package com.adobe.marketing.mobile.optimize;
 
+import static com.adobe.marketing.mobile.optimize.AEPOptimizeError.toAEPOptimizeError;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.adobe.marketing.mobile.AdobeCallback;
@@ -176,8 +177,8 @@ public class Optimize {
                             if (eventData.containsKey(
                                     OptimizeConstants.EventDataKeys.RESPONSE_ERROR)) {
                                 Object error =  eventData.get(OptimizeConstants.EventDataKeys.RESPONSE_ERROR);
-                                if (error instanceof AEPOptimizeError) {
-                                    failWithOptimizeError(callback, (AEPOptimizeError) error);
+                                if (error instanceof Map) {
+                                    failWithOptimizeError(callback, toAEPOptimizeError((Map<String, ? extends Object>) error));
                                 }
                             }
 

--- a/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/OptimizeConstants.java
+++ b/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/OptimizeConstants.java
@@ -29,6 +29,7 @@ class OptimizeConstants {
     static final String XDM_NAME = "xdm:name";
 
     static final String ERROR_UNKNOWN = "unknown";
+    static final Integer UNKNOWN_STATUS = 0;
 
     private OptimizeConstants() {}
 
@@ -203,4 +204,19 @@ class OptimizeConstants {
 
         private ErrorData() {}
     }
+
+    static final class HTTPResponseCodes {
+        static final int success = 200;
+        static final int noContent = 204;
+        static final int multiStatus = 207;
+        static final int invalidRequest = 400;
+        static final int clientTimeout = 408;
+        static final int tooManyRequests = 429;
+        static final int internalServerError = 500;
+        static final int badGateway = 502;
+        static final int serviceUnavailable = 503;
+        static final int gatewayTimeout = 504;
+        private HTTPResponseCodes() {}
+    }
+
 }

--- a/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/OptimizeConstants.java
+++ b/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/OptimizeConstants.java
@@ -216,7 +216,7 @@ class OptimizeConstants {
         static final int badGateway = 502;
         static final int serviceUnavailable = 503;
         static final int gatewayTimeout = 504;
+
         private HTTPResponseCodes() {}
     }
-
 }

--- a/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/OptimizeExtension.java
+++ b/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/OptimizeExtension.java
@@ -421,7 +421,7 @@ class OptimizeExtension extends Extension {
                             if (aepOptimizeError != null) {
                                 responseEventData.put(
                                         OptimizeConstants.EventDataKeys.RESPONSE_ERROR,
-                                        aepOptimizeError.toMap());
+                                        aepOptimizeError.toEventData());
                             }
 
                             final List<Map<String, Object>> propositionsList = new ArrayList<>();

--- a/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/OptimizeExtension.java
+++ b/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/OptimizeExtension.java
@@ -420,13 +420,18 @@ class OptimizeExtension extends Extension {
                             if(aepOptimizeError != null){
                                 responseEventData.put(OptimizeConstants.EventDataKeys.RESPONSE_ERROR,
                                         aepOptimizeError.toMap());
-                                responseEventData.put("propositions",
-                                        aepOptimizeError.toMap());
                             }
 
-                            /*responseEventData.put(
+                            final List<Map<String, Object>> propositionsList = new ArrayList<>();
+
+                            for (Map.Entry<DecisionScope, OptimizeProposition> entry : propositionsInProgress.entrySet()) {
+                                OptimizeProposition optimizeProposition = entry.getValue();
+                                propositionsList.add(optimizeProposition.toEventData());
+                            }
+
+                            responseEventData.put(
                                     OptimizeConstants.EventDataKeys.PROPOSITIONS,
-                                    propositionsInProgress);*/
+                                    propositionsList);
 
                             final Event responseEvent =
                                     new Event.Builder(

--- a/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/OptimizeExtension.java
+++ b/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/OptimizeExtension.java
@@ -673,7 +673,6 @@ class OptimizeExtension extends Extension {
             }
 
             if (OptimizeUtils.isNullOrEmpty(event.getEventData())) {
-                // todo
                 Log.debug(
                         OptimizeConstants.LOG_TAG,
                         SELF_TAG,

--- a/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/OptimizeExtension.java
+++ b/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/OptimizeExtension.java
@@ -417,12 +417,16 @@ class OptimizeExtension extends Extension {
 
                             final Map<String, Object> responseEventData = new HashMap<>();
                             AEPOptimizeError aepOptimizeError = updateRequestEventIdsErrors.get(requestEventId);
-                            responseEventData.put(OptimizeConstants.EventDataKeys.RESPONSE_ERROR,
-                                    aepOptimizeError);
+                            if(aepOptimizeError != null){
+                                responseEventData.put(OptimizeConstants.EventDataKeys.RESPONSE_ERROR,
+                                        aepOptimizeError.toMap());
+                                responseEventData.put("propositions",
+                                        aepOptimizeError.toMap());
+                            }
 
-                            responseEventData.put(
+                            /*responseEventData.put(
                                     OptimizeConstants.EventDataKeys.PROPOSITIONS,
-                                    propositionsInProgress);
+                                    propositionsInProgress);*/
 
                             final Event responseEvent =
                                     new Event.Builder(

--- a/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/OptimizeExtension.java
+++ b/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/OptimizeExtension.java
@@ -94,17 +94,17 @@ class OptimizeExtension extends Extension {
                     OptimizeConstants.JsonValues.SCHEMA_OFFER_TEXT);
 
     // List containing recoverable network error codes being retried by Edge Network Service
-    private static final List<Integer> recoverableNetworkErrorCodes = Arrays.asList(
-            OptimizeConstants.HTTPResponseCodes.clientTimeout,
-            OptimizeConstants.HTTPResponseCodes.tooManyRequests,
-            OptimizeConstants.HTTPResponseCodes.badGateway,
-            OptimizeConstants.HTTPResponseCodes.serviceUnavailable,
-            OptimizeConstants.HTTPResponseCodes.gatewayTimeout
-    );
+    private static final List<Integer> recoverableNetworkErrorCodes =
+            Arrays.asList(
+                    OptimizeConstants.HTTPResponseCodes.clientTimeout,
+                    OptimizeConstants.HTTPResponseCodes.tooManyRequests,
+                    OptimizeConstants.HTTPResponseCodes.badGateway,
+                    OptimizeConstants.HTTPResponseCodes.serviceUnavailable,
+                    OptimizeConstants.HTTPResponseCodes.gatewayTimeout);
 
-    //Map containing the update event IDs and corresponding errors as received from Edge SDK
-    private static final Map<String, AEPOptimizeError> updateRequestEventIdsErrors = new ConcurrentHashMap<>();
-
+    // Map containing the update event IDs and corresponding errors as received from Edge SDK
+    private static final Map<String, AEPOptimizeError> updateRequestEventIdsErrors =
+            new ConcurrentHashMap<>();
 
     /**
      * Constructor for {@code OptimizeExtension}.
@@ -136,36 +136,36 @@ class OptimizeExtension extends Extension {
     @Override
     protected void onRegistered() {
         getApi().registerEventListener(
-                OptimizeConstants.EventType.OPTIMIZE,
-                OptimizeConstants.EventSource.REQUEST_CONTENT,
-                this::handleOptimizeRequestContent);
+                        OptimizeConstants.EventType.OPTIMIZE,
+                        OptimizeConstants.EventSource.REQUEST_CONTENT,
+                        this::handleOptimizeRequestContent);
 
         getApi().registerEventListener(
-                OptimizeConstants.EventType.EDGE,
-                OptimizeConstants.EventSource.EDGE_PERSONALIZATION_DECISIONS,
-                this::handleEdgeResponse);
+                        OptimizeConstants.EventType.EDGE,
+                        OptimizeConstants.EventSource.EDGE_PERSONALIZATION_DECISIONS,
+                        this::handleEdgeResponse);
 
         getApi().registerEventListener(
-                OptimizeConstants.EventType.EDGE,
-                OptimizeConstants.EventSource.ERROR_RESPONSE_CONTENT,
-                this::handleEdgeErrorResponse);
+                        OptimizeConstants.EventType.EDGE,
+                        OptimizeConstants.EventSource.ERROR_RESPONSE_CONTENT,
+                        this::handleEdgeErrorResponse);
 
         getApi().registerEventListener(
-                OptimizeConstants.EventType.OPTIMIZE,
-                OptimizeConstants.EventSource.REQUEST_RESET,
-                this::handleClearPropositions);
+                        OptimizeConstants.EventType.OPTIMIZE,
+                        OptimizeConstants.EventSource.REQUEST_RESET,
+                        this::handleClearPropositions);
 
         // Register listener - Mobile Core `resetIdentities()` API dispatches generic identity
         // request reset event.
         getApi().registerEventListener(
-                OptimizeConstants.EventType.GENERIC_IDENTITY,
-                OptimizeConstants.EventSource.REQUEST_RESET,
-                this::handleClearPropositions);
+                        OptimizeConstants.EventType.GENERIC_IDENTITY,
+                        OptimizeConstants.EventSource.REQUEST_RESET,
+                        this::handleClearPropositions);
 
         getApi().registerEventListener(
-                OptimizeConstants.EventType.OPTIMIZE,
-                OptimizeConstants.EventSource.CONTENT_COMPLETE,
-                this::handleUpdatePropositionsCompleted);
+                        OptimizeConstants.EventType.OPTIMIZE,
+                        OptimizeConstants.EventSource.CONTENT_COMPLETE,
+                        this::handleUpdatePropositionsCompleted);
 
         eventsDispatcher.start();
     }
@@ -174,13 +174,13 @@ class OptimizeExtension extends Extension {
     public boolean readyForEvent(@NonNull final Event event) {
         if (OptimizeConstants.EventType.OPTIMIZE.equalsIgnoreCase(event.getType())
                 && OptimizeConstants.EventSource.REQUEST_CONTENT.equalsIgnoreCase(
-                event.getSource())) {
+                        event.getSource())) {
             SharedStateResult configurationSharedState =
                     getApi().getSharedState(
-                            OptimizeConstants.Configuration.EXTENSION_NAME,
-                            event,
-                            false,
-                            SharedStateResolution.ANY);
+                                    OptimizeConstants.Configuration.EXTENSION_NAME,
+                                    event,
+                                    false,
+                                    SharedStateResolution.ANY);
             return configurationSharedState != null
                     && configurationSharedState.getStatus() == SharedStateStatus.SET;
         }
@@ -365,9 +365,9 @@ class OptimizeExtension extends Extension {
 
             final Event edgeEvent =
                     new Event.Builder(
-                            OptimizeConstants.EventNames.EDGE_PERSONALIZATION_REQUEST,
-                            OptimizeConstants.EventType.EDGE,
-                            OptimizeConstants.EventSource.REQUEST_CONTENT)
+                                    OptimizeConstants.EventNames.EDGE_PERSONALIZATION_REQUEST,
+                                    OptimizeConstants.EventType.EDGE,
+                                    OptimizeConstants.EventSource.REQUEST_CONTENT)
                             .setEventData(edgeEventData)
                             .chainToParentEvent(event)
                             .build();
@@ -401,7 +401,7 @@ class OptimizeExtension extends Extension {
                             }
 
                             getApi().dispatch(
-                                    createResponseEventWithError(event, aepOptimizeError));
+                                            createResponseEventWithError(event, aepOptimizeError));
 
                             eventsDispatcher.resume();
                         }
@@ -416,28 +416,30 @@ class OptimizeExtension extends Extension {
                             }
 
                             final Map<String, Object> responseEventData = new HashMap<>();
-                            AEPOptimizeError aepOptimizeError = updateRequestEventIdsErrors.get(requestEventId);
-                            if(aepOptimizeError != null){
-                                responseEventData.put(OptimizeConstants.EventDataKeys.RESPONSE_ERROR,
+                            AEPOptimizeError aepOptimizeError =
+                                    updateRequestEventIdsErrors.get(requestEventId);
+                            if (aepOptimizeError != null) {
+                                responseEventData.put(
+                                        OptimizeConstants.EventDataKeys.RESPONSE_ERROR,
                                         aepOptimizeError.toMap());
                             }
 
                             final List<Map<String, Object>> propositionsList = new ArrayList<>();
 
-                            for (Map.Entry<DecisionScope, OptimizeProposition> entry : propositionsInProgress.entrySet()) {
+                            for (Map.Entry<DecisionScope, OptimizeProposition> entry :
+                                    propositionsInProgress.entrySet()) {
                                 OptimizeProposition optimizeProposition = entry.getValue();
                                 propositionsList.add(optimizeProposition.toEventData());
                             }
 
                             responseEventData.put(
-                                    OptimizeConstants.EventDataKeys.PROPOSITIONS,
-                                    propositionsList);
+                                    OptimizeConstants.EventDataKeys.PROPOSITIONS, propositionsList);
 
                             final Event responseEvent =
                                     new Event.Builder(
-                                            OptimizeConstants.EventNames.OPTIMIZE_RESPONSE,
-                                            OptimizeConstants.EventType.OPTIMIZE,
-                                            OptimizeConstants.EventSource.RESPONSE_CONTENT)
+                                                    OptimizeConstants.EventNames.OPTIMIZE_RESPONSE,
+                                                    OptimizeConstants.EventType.OPTIMIZE,
+                                                    OptimizeConstants.EventSource.RESPONSE_CONTENT)
                                             .setEventData(responseEventData)
                                             .inResponseToEvent(event)
                                             .build();
@@ -446,10 +448,10 @@ class OptimizeExtension extends Extension {
 
                             final Event updateCompleteEvent =
                                     new Event.Builder(
-                                            OptimizeConstants.EventNames
-                                                    .OPTIMIZE_UPDATE_COMPLETE,
-                                            OptimizeConstants.EventType.OPTIMIZE,
-                                            OptimizeConstants.EventSource.CONTENT_COMPLETE)
+                                                    OptimizeConstants.EventNames
+                                                            .OPTIMIZE_UPDATE_COMPLETE,
+                                                    OptimizeConstants.EventType.OPTIMIZE,
+                                                    OptimizeConstants.EventSource.CONTENT_COMPLETE)
                                             .setEventData(
                                                     new HashMap<String, Object>() {
                                                         {
@@ -506,8 +508,8 @@ class OptimizeExtension extends Extension {
                         OptimizeConstants.LOG_TAG,
                         SELF_TAG,
                         "handleUpdatePropositionsCompleted - Ignoring Optimize complete event,"
-                                + " event Id is not being tracked for completion as requested scopes is"
-                                + " null or empty.");
+                            + " event Id is not being tracked for completion as requested scopes is"
+                            + " null or empty.");
                 return;
             }
 
@@ -574,8 +576,8 @@ class OptimizeExtension extends Extension {
                         OptimizeConstants.LOG_TAG,
                         SELF_TAG,
                         "handleEdgeResponse - Ignoring Edge event, either handle type is not"
-                                + " personalization:decisions, or the response isn't intended for this"
-                                + " extension.");
+                            + " personalization:decisions, or the response isn't intended for this"
+                            + " extension.");
                 propositionsInProgress.clear();
                 return;
             }
@@ -609,8 +611,8 @@ class OptimizeExtension extends Extension {
                         OptimizeConstants.LOG_TAG,
                         SELF_TAG,
                         "handleEdgeResponse - Cannot process the Edge personalization:decisions"
-                                + " event, no propositions with valid offers are present in the Edge"
-                                + " response.");
+                            + " event, no propositions with valid offers are present in the Edge"
+                            + " response.");
                 return;
             }
 
@@ -626,9 +628,9 @@ class OptimizeExtension extends Extension {
 
             final Event edgeEvent =
                     new Event.Builder(
-                            OptimizeConstants.EventNames.OPTIMIZE_NOTIFICATION,
-                            OptimizeConstants.EventType.OPTIMIZE,
-                            OptimizeConstants.EventSource.NOTIFICATION)
+                                    OptimizeConstants.EventNames.OPTIMIZE_NOTIFICATION,
+                                    OptimizeConstants.EventType.OPTIMIZE,
+                                    OptimizeConstants.EventSource.NOTIFICATION)
                             .setEventData(notificationData)
                             .build();
 
@@ -664,19 +666,19 @@ class OptimizeExtension extends Extension {
                 Log.debug(
                         OptimizeConstants.LOG_TAG,
                         SELF_TAG,
-                        "handleEdgeResponse - Ignoring Edge event, either handle type is not"
-                                + " edge error response content, or the response isn't intended for this"
+                        "handleEdgeResponse - Ignoring Edge event, either handle type is not edge"
+                                + " error response content, or the response isn't intended for this"
                                 + " extension.");
                 return;
             }
 
             if (OptimizeUtils.isNullOrEmpty(event.getEventData())) {
-                //todo
+                // todo
                 Log.debug(
                         OptimizeConstants.LOG_TAG,
                         SELF_TAG,
-                        "handleEdgeErrorResponse - Ignoring the Edge error response event, either event"
-                                + " is null or event data is null/ empty.");
+                        "handleEdgeErrorResponse - Ignoring the Edge error response event, either"
+                                + " event is null or event data is null/ empty.");
                 return;
             }
 
@@ -689,8 +691,7 @@ class OptimizeExtension extends Extension {
                     DataReader.optInt(
                             eventData,
                             OptimizeConstants.Edge.ErrorKeys.STATUS,
-                            OptimizeConstants.UNKNOWN_STATUS
-                    );
+                            OptimizeConstants.UNKNOWN_STATUS);
             final String errorTitle =
                     DataReader.optString(
                             eventData,
@@ -706,13 +707,16 @@ class OptimizeExtension extends Extension {
                             Object.class,
                             eventData,
                             OptimizeConstants.Edge.ErrorKeys.REPORT,
-                            new HashMap<>()
-                    );
+                            new HashMap<>());
 
             Log.warning(
                     OptimizeConstants.LOG_TAG,
                     SELF_TAG,
-                    "handleEdgeErrorResponse - Decisioning Service error! Error type: (%s),\ntitle: (%s),\ndetail: (%s),\nstatus: (%s),\nreport: (%s)",
+                    "handleEdgeErrorResponse - Decisioning Service error! Error type: (%s),\n"
+                            + "title: (%s),\n"
+                            + "detail: (%s),\n"
+                            + "status: (%s),\n"
+                            + "report: (%s)",
                     errorType,
                     errorTitle,
                     errorDetail,
@@ -724,18 +728,13 @@ class OptimizeExtension extends Extension {
                 Log.debug(
                         OptimizeConstants.LOG_TAG,
                         SELF_TAG,
-                        "Recoverable error encountered: Status %d", errorStatus
-                );
+                        "Recoverable error encountered: Status %d",
+                        errorStatus);
                 return;
             } else {
-                AEPOptimizeError aepOptimizeError = new AEPOptimizeError(
-                        errorType,
-                        errorStatus,
-                        errorTitle,
-                        errorDetail,
-                        errorReport,
-                        null
-                );
+                AEPOptimizeError aepOptimizeError =
+                        new AEPOptimizeError(
+                                errorType, errorStatus, errorTitle, errorDetail, errorReport, null);
                 updateRequestEventIdsErrors.put(requestEventId, aepOptimizeError);
             }
         } catch (final Exception e) {
@@ -791,9 +790,9 @@ class OptimizeExtension extends Extension {
 
             final Event responseEvent =
                     new Event.Builder(
-                            OptimizeConstants.EventNames.OPTIMIZE_RESPONSE,
-                            OptimizeConstants.EventType.OPTIMIZE,
-                            OptimizeConstants.EventSource.RESPONSE_CONTENT)
+                                    OptimizeConstants.EventNames.OPTIMIZE_RESPONSE,
+                                    OptimizeConstants.EventType.OPTIMIZE,
+                                    OptimizeConstants.EventSource.RESPONSE_CONTENT)
                             .setEventData(responseEventData)
                             .inResponseToEvent(event)
                             .build();
@@ -846,7 +845,7 @@ class OptimizeExtension extends Extension {
                         OptimizeConstants.LOG_TAG,
                         SELF_TAG,
                         "handleTrackPropositions - Cannot process the track propositions request"
-                                + " event, provided proposition interactions map is null or empty.");
+                            + " event, provided proposition interactions map is null or empty.");
                 return;
             }
 
@@ -867,10 +866,10 @@ class OptimizeExtension extends Extension {
 
             final Event edgeEvent =
                     new Event.Builder(
-                            OptimizeConstants.EventNames
-                                    .EDGE_PROPOSITION_INTERACTION_REQUEST,
-                            OptimizeConstants.EventType.EDGE,
-                            OptimizeConstants.EventSource.REQUEST_CONTENT)
+                                    OptimizeConstants.EventNames
+                                            .EDGE_PROPOSITION_INTERACTION_REQUEST,
+                                    OptimizeConstants.EventType.EDGE,
+                                    OptimizeConstants.EventSource.REQUEST_CONTENT)
                             .setEventData(edgeEventData)
                             .build();
 
@@ -907,10 +906,10 @@ class OptimizeExtension extends Extension {
     private Map<String, Object> retrieveConfigurationSharedState(final Event event) {
         SharedStateResult configurationSharedState =
                 getApi().getSharedState(
-                        OptimizeConstants.Configuration.EXTENSION_NAME,
-                        event,
-                        false,
-                        SharedStateResolution.ANY);
+                                OptimizeConstants.Configuration.EXTENSION_NAME,
+                                event,
+                                false,
+                                SharedStateResolution.ANY);
         return configurationSharedState != null ? configurationSharedState.getValue() : null;
     }
 
@@ -968,9 +967,9 @@ class OptimizeExtension extends Extension {
         eventData.put(OptimizeConstants.EventDataKeys.RESPONSE_ERROR, error.getErrorCode());
 
         return new Event.Builder(
-                OptimizeConstants.EventNames.OPTIMIZE_RESPONSE,
-                OptimizeConstants.EventType.OPTIMIZE,
-                OptimizeConstants.EventSource.RESPONSE_CONTENT)
+                        OptimizeConstants.EventNames.OPTIMIZE_RESPONSE,
+                        OptimizeConstants.EventType.OPTIMIZE,
+                        OptimizeConstants.EventSource.RESPONSE_CONTENT)
                 .setEventData(eventData)
                 .inResponseToEvent(event)
                 .build();
@@ -981,9 +980,9 @@ class OptimizeExtension extends Extension {
         eventData.put(OptimizeConstants.EventDataKeys.RESPONSE_ERROR, error);
 
         return new Event.Builder(
-                OptimizeConstants.EventNames.OPTIMIZE_RESPONSE,
-                OptimizeConstants.EventType.OPTIMIZE,
-                OptimizeConstants.EventSource.RESPONSE_CONTENT)
+                        OptimizeConstants.EventNames.OPTIMIZE_RESPONSE,
+                        OptimizeConstants.EventType.OPTIMIZE,
+                        OptimizeConstants.EventSource.RESPONSE_CONTENT)
                 .setEventData(eventData)
                 .inResponseToEvent(event)
                 .build();

--- a/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/OptimizeUtils.java
+++ b/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/OptimizeUtils.java
@@ -139,22 +139,19 @@ class OptimizeUtils {
                         event.getSource());
     }
 
-
     /**
      * Checks whether the given event is a edge error response content response returned from the
      * Edge network.
      *
      * @param event instance of {@link Event}
-     * @return {@code boolean} containing true if event is a edge error response content event, false
-     *     otherwise.
+     * @return {@code boolean} containing true if event is a edge error response content event,
+     *     false otherwise.
      */
     static boolean isEdgeErrorResponseContent(final Event event) {
         return OptimizeConstants.EventType.EDGE.equalsIgnoreCase(event.getType())
                 && OptimizeConstants.EventSource.ERROR_RESPONSE_CONTENT.equalsIgnoreCase(
-                event.getSource());
+                        event.getSource());
     }
-
-
 
     /**
      * Checks whether the given event is an Optimize request content event for retrieving cached

--- a/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/OptimizeUtils.java
+++ b/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/OptimizeUtils.java
@@ -139,6 +139,23 @@ class OptimizeUtils {
                         event.getSource());
     }
 
+
+    /**
+     * Checks whether the given event is a edge error response content response returned from the
+     * Edge network.
+     *
+     * @param event instance of {@link Event}
+     * @return {@code boolean} containing true if event is a edge error response content event, false
+     *     otherwise.
+     */
+    static boolean isEdgeErrorResponseContent(final Event event) {
+        return OptimizeConstants.EventType.EDGE.equalsIgnoreCase(event.getType())
+                && OptimizeConstants.EventSource.ERROR_RESPONSE_CONTENT.equalsIgnoreCase(
+                event.getSource());
+    }
+
+
+
     /**
      * Checks whether the given event is an Optimize request content event for retrieving cached
      * propositions.

--- a/code/optimize/src/test/java/com/adobe/marketing/mobile/optimize/AEPOptimizeErrorTest.kt
+++ b/code/optimize/src/test/java/com/adobe/marketing/mobile/optimize/AEPOptimizeErrorTest.kt
@@ -1,0 +1,94 @@
+package com.adobe.marketing.mobile.optimize
+
+import com.adobe.marketing.mobile.AdobeError
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class AEPOptimizeErrorTest {
+
+    @Test
+    fun `test toEventData without AdobeError`() {
+        // Arrange
+        val reportData: Map<String, Any> = mapOf("key1" to "value1", "key2" to "value2")
+        val aepOptimizeError = AEPOptimizeError(
+            type = "SomeErrorType",
+            status = 100,
+            title = "Not Found",
+            detail = "The requested resource could not be found",
+            report = reportData,
+            adobeError = null
+        )
+
+        // Act
+        val eventData = aepOptimizeError.toEventData()
+
+        // Assert
+        assertEquals("SomeErrorType", eventData[AEPOptimizeError.TYPE])
+        assertEquals(100, eventData[AEPOptimizeError.STATUS])
+        assertEquals("Not Found", eventData[AEPOptimizeError.TITLE])
+        assertEquals(
+            "The requested resource could not be found",
+            eventData[AEPOptimizeError.DETAIL]
+        )
+        assertEquals(reportData, eventData[AEPOptimizeError.REPORT])
+        //assertNull(eventData[AEPOptimizeError.ADOBE_ERROR])
+    }
+
+    @Test
+    fun `test toEventData with AdobeError`() {
+        // Arrange
+        val adobeError = AdobeError.UNEXPECTED_ERROR
+        val aepOptimizeError = AEPOptimizeError(
+            type = "SomeErrorType",
+            status = 500,
+            title = "Internal Server Error",
+            detail = "An unexpected error occurred",
+            report = null,
+            adobeError = adobeError
+        )
+
+        // Act
+        val eventData = aepOptimizeError.toEventData()
+
+        // Assert
+        assertEquals("SomeErrorType", eventData[AEPOptimizeError.TYPE])
+        assertEquals(500, eventData[AEPOptimizeError.STATUS])
+        assertEquals("Internal Server Error", eventData[AEPOptimizeError.TITLE])
+        assertEquals("An unexpected error occurred", eventData[AEPOptimizeError.DETAIL])
+        assertNull(eventData[AEPOptimizeError.REPORT])
+        assertNotNull(eventData[AEPOptimizeError.ADOBE_ERROR])
+
+        val adobeErrorData = eventData[AEPOptimizeError.ADOBE_ERROR] as Map<String, Any?>
+        assertEquals(adobeError.errorName, adobeErrorData[AEPOptimizeError.ERROR_NAME])
+        assertEquals(adobeError.errorCode, adobeErrorData[AEPOptimizeError.ERROR_CODE])
+    }
+
+    @Test
+    fun `test toAEPOptimizeError`() {
+        // Arrange
+        val data: Map<String, Any?> = mapOf(
+            AEPOptimizeError.TYPE to "SomeErrorType",
+            AEPOptimizeError.STATUS to 400,
+            AEPOptimizeError.TITLE to "Bad Request",
+            AEPOptimizeError.DETAIL to "Invalid request",
+            AEPOptimizeError.REPORT to null,
+            AEPOptimizeError.ADOBE_ERROR to mapOf(
+                AEPOptimizeError.ERROR_NAME to AdobeError.UNEXPECTED_ERROR.errorName,
+                AEPOptimizeError.ERROR_CODE to AdobeError.UNEXPECTED_ERROR.errorCode
+            )
+        )
+
+        // Act
+        val aepOptimizeError = AEPOptimizeError.toAEPOptimizeError(data)
+
+        // Assert
+        assertEquals("SomeErrorType", aepOptimizeError.type)
+        assertEquals(400, aepOptimizeError.status)
+        assertEquals("Bad Request", aepOptimizeError.title)
+        assertEquals("Invalid request", aepOptimizeError.detail)
+        assertNull(aepOptimizeError.report)
+        assertEquals(AdobeError.UNEXPECTED_ERROR, aepOptimizeError.adobeError)
+    }
+}

--- a/code/optimize/src/test/java/com/adobe/marketing/mobile/optimize/AEPOptimizeErrorTest.kt
+++ b/code/optimize/src/test/java/com/adobe/marketing/mobile/optimize/AEPOptimizeErrorTest.kt
@@ -1,3 +1,14 @@
+/*
+  Copyright 2024 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
 package com.adobe.marketing.mobile.optimize
 
 import com.adobe.marketing.mobile.AdobeError
@@ -14,7 +25,7 @@ class AEPOptimizeErrorTest {
         val reportData: Map<String, Any> = mapOf("key1" to "value1", "key2" to "value2")
         val aepOptimizeError = AEPOptimizeError(
             type = "SomeErrorType",
-            status = 100,
+            status = 404,
             title = "Not Found",
             detail = "The requested resource could not be found",
             report = reportData,
@@ -26,14 +37,14 @@ class AEPOptimizeErrorTest {
 
         // Assert
         assertEquals("SomeErrorType", eventData[AEPOptimizeError.TYPE])
-        assertEquals(100, eventData[AEPOptimizeError.STATUS])
+        assertEquals(404, eventData[AEPOptimizeError.STATUS])
         assertEquals("Not Found", eventData[AEPOptimizeError.TITLE])
         assertEquals(
             "The requested resource could not be found",
             eventData[AEPOptimizeError.DETAIL]
         )
         assertEquals(reportData, eventData[AEPOptimizeError.REPORT])
-        //assertNull(eventData[AEPOptimizeError.ADOBE_ERROR])
+        assertNotNull(eventData[AEPOptimizeError.ADOBE_ERROR])
     }
 
     @Test

--- a/code/optimize/src/test/java/com/adobe/marketing/mobile/optimize/OptimizeExtensionTests.java
+++ b/code/optimize/src/test/java/com/adobe/marketing/mobile/optimize/OptimizeExtensionTests.java
@@ -1269,6 +1269,17 @@ public class OptimizeExtensionTests {
                                             .getResource(
                                                     "json/EVENT_DATA_EDGE_ERROR_RESPONSE.json"),
                                     HashMap.class);
+
+            extension.setUpdateRequestEventIdsInProgress(
+                    "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA",
+                    new ArrayList<DecisionScope>() {
+                        {
+                            add(
+                                    new DecisionScope(
+                                            "eydhY3Rpdml0eUlkIjoieGNvcmU6b2ZmZXItYWN0aXZpdHk6MTExMTExMTExMTExMTExMSIsInBsYWNlbWVudElkIjoieGNvcmU6b2ZmZXItcGxhY2VtZW50OjExMTExMTExMTExMTExMTEifQ=="));
+                        }
+                    });
+
             final Event testEvent =
                     new Event.Builder(
                                     "AEP Error Response",

--- a/code/testapp/build.gradle.kts
+++ b/code/testapp/build.gradle.kts
@@ -54,7 +54,7 @@ android {
 
 dependencies {
     implementation(project(":optimize"))
-    implementation("com.adobe.marketing.mobile:core:3.0.0")
+    implementation("com.adobe.marketing.mobile:core:3.2.0")
     implementation("com.adobe.marketing.mobile:edge:3.0.0")
     implementation("com.adobe.marketing.mobile:edgeidentity:3.0.0")
     implementation("com.adobe.marketing.mobile:assurance:3.0.0")

--- a/code/testapp/src/main/java/com/adobe/marketing/optimizeapp/viewmodels/MainViewModel.kt
+++ b/code/testapp/src/main/java/com/adobe/marketing/optimizeapp/viewmodels/MainViewModel.kt
@@ -11,10 +11,13 @@
  */
 package com.adobe.marketing.optimizeapp.viewmodels
 
+import android.util.Log
 import androidx.compose.runtime.*
 import androidx.lifecycle.ViewModel
 import com.adobe.marketing.mobile.AdobeCallbackWithError
 import com.adobe.marketing.mobile.AdobeError
+import com.adobe.marketing.mobile.optimize.AEPOptimizeError
+import com.adobe.marketing.mobile.optimize.AdobeCallbackWithOptimizeError
 import com.adobe.marketing.mobile.optimize.DecisionScope
 import com.adobe.marketing.mobile.optimize.Optimize
 import com.adobe.marketing.mobile.optimize.OptimizeProposition
@@ -94,7 +97,16 @@ class MainViewModel: ViewModel() {
      */
     fun updatePropositions(decisionScopes: List<DecisionScope> , xdm: Map<String, String> , data: Map<String, Any>) {
         optimizePropositionStateMap.clear()
-        Optimize.updatePropositions(decisionScopes, xdm, data)
+        Optimize.updatePropositions(decisionScopes, xdm, data, object: AdobeCallbackWithOptimizeError<Map<DecisionScope, OptimizeProposition>>{
+            override fun call(propositions: Map<DecisionScope, OptimizeProposition>?) {
+                Log.i("Optimize Test App","Propositions updated successfully.")
+            }
+
+            override fun fail(error: AEPOptimizeError?) {
+                Log.i("Optimize Test App","Error in updating Propositions:: ${error?.title ?: "Undefined"}.")
+            }
+
+        })
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
This PR supports handling of error response received (if any) from Experience Edge and sending them back to update Proposition api's completion handler. Currently we are suppressing recoverable errors at our end as those are already being retried on Edge SDK.


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
