### PR TITLE
Change the type of offer score from int to double

### DIFF
--- a/code/optimize/src/androidTest/java/com/adobe/marketing/mobile/optimize/OptimizeFunctionalTests.java
+++ b/code/optimize/src/androidTest/java/com/adobe/marketing/mobile/optimize/OptimizeFunctionalTests.java
@@ -43,6 +43,8 @@ import org.junit.runner.RunWith;
 @RunWith(AndroidJUnit4.class)
 public class OptimizeFunctionalTests {
 
+    double doubleAccuracy = 0.001;
+
     @Rule
     public RuleChain ruleChain =
             RuleChain.outerRule(new TestHelper.SetupCoreRule())
@@ -697,7 +699,7 @@ public class OptimizeFunctionalTests {
         Offer offer = optimizeProposition.getOffers().get(0);
         Assert.assertEquals("xcore:personalized-offer:1111111111111111", offer.getId());
         Assert.assertEquals("10", offer.getEtag());
-        Assert.assertEquals(1, offer.getScore());
+        Assert.assertEquals(1, offer.getScore(), doubleAccuracy);
         Assert.assertEquals(
                 "https://ns.adobe.com/experience/offer-management/content-component-html",
                 offer.getSchema());
@@ -867,7 +869,7 @@ public class OptimizeFunctionalTests {
         Offer offer = optimizeProposition.getOffers().get(0);
         Assert.assertEquals("0", offer.getId());
         Assert.assertEquals(null, offer.getEtag());
-        Assert.assertEquals(0, offer.getScore());
+        Assert.assertEquals(0, offer.getScore(), doubleAccuracy);
         Assert.assertEquals(
                 "https://ns.adobe.com/personalization/default-content-item", offer.getSchema());
         Assert.assertEquals(OfferType.UNKNOWN, offer.getType());

--- a/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/Offer.java
+++ b/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/Offer.java
@@ -29,7 +29,7 @@ public class Offer {
     private static final String SELF_TAG = "Offer";
     private String id;
     private String etag;
-    private int score;
+    private double score;
     private String schema;
     private Map<String, Object> meta;
     private OfferType type;
@@ -66,7 +66,7 @@ public class Offer {
             offer.type = type != null ? type : OfferType.UNKNOWN;
             offer.content = content != null ? content : "";
             offer.etag = "";
-            offer.score = 0;
+            offer.score = 0.0;
             offer.schema = "";
             offer.meta = new HashMap<>();
             offer.language = new ArrayList<>();
@@ -92,12 +92,12 @@ public class Offer {
         /**
          * Sets the score for this {@code Offer}.
          *
-         * @param score {@code int} containing {@link Offer} score.
+         * @param score {@code double} containing {@link Offer} score.
          * @return this Offer {@link Builder}
          * @throws UnsupportedOperationException if this method is invoked after {@link
          *     Builder#build()}.
          */
-        public Builder setScore(final int score) {
+        public Builder setScore(final double score) {
             throwIfAlreadyBuilt();
 
             offer.score = score;
@@ -206,9 +206,9 @@ public class Offer {
     /**
      * Gets the {@code Offer} score.
      *
-     * @return {@code int} containing the {@link Offer} score.
+     * @return {@code double} containing the {@link Offer} score.
      */
-    public int getScore() {
+    public double getScore() {
         return score;
     }
 
@@ -446,8 +446,8 @@ public class Offer {
                     DataReader.getString(data, OptimizeConstants.JsonKeys.PAYLOAD_ITEM_ID);
             final String etag =
                     DataReader.getString(data, OptimizeConstants.JsonKeys.PAYLOAD_ITEM_ETAG);
-            final int score =
-                    DataReader.optInt(data, OptimizeConstants.JsonKeys.PAYLOAD_ITEM_SCORE, 0);
+            final double score =
+                    DataReader.optDouble(data, OptimizeConstants.JsonKeys.PAYLOAD_ITEM_SCORE, 0.0);
             final String schema =
                     DataReader.getString(data, OptimizeConstants.JsonKeys.PAYLOAD_ITEM_SCHEMA);
 
@@ -534,7 +534,7 @@ public class Offer {
                                 + " empty string.");
                 return new Builder(id, OfferType.UNKNOWN, "")
                         .setEtag(null)
-                        .setScore(0)
+                        .setScore(0.0)
                         .setSchema(schema)
                         .setMeta(meta)
                         .setLanguage(null)

--- a/code/optimize/src/test/java/com/adobe/marketing/mobile/optimize/OfferTests.java
+++ b/code/optimize/src/test/java/com/adobe/marketing/mobile/optimize/OfferTests.java
@@ -32,6 +32,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 @SuppressWarnings("unchecked")
 public class OfferTests {
 
+    double doubleAccuracy = 0.001;
+
     @Test
     public void testBuilder_validOffer() {
         final Offer offer =
@@ -59,7 +61,7 @@ public class OfferTests {
 
         Assert.assertEquals("xcore:personalized-offer:2222222222222222", offer.getId());
         Assert.assertEquals("7", offer.getEtag());
-        Assert.assertEquals(2, offer.getScore());
+        Assert.assertEquals(2, offer.getScore(), doubleAccuracy);
         Assert.assertEquals(
                 "https://ns.adobe.com/experience/offer-management/content-component-text",
                 offer.getSchema());
@@ -85,7 +87,7 @@ public class OfferTests {
 
         Assert.assertEquals("xcore:personalized-offer:1111111111111111", offer.getId());
         Assert.assertEquals("8", offer.getEtag());
-        Assert.assertEquals(0, offer.getScore());
+        Assert.assertEquals(0, offer.getScore(), doubleAccuracy);
         Assert.assertEquals(
                 "https://ns.adobe.com/experience/offer-management/content-component-json",
                 offer.getSchema());
@@ -111,7 +113,7 @@ public class OfferTests {
 
         Assert.assertEquals("xcore:personalized-offer:2222222222222222", offer.getId());
         Assert.assertEquals("7", offer.getEtag());
-        Assert.assertEquals(0, offer.getScore());
+        Assert.assertEquals(0, offer.getScore(), doubleAccuracy);
         Assert.assertEquals(
                 "https://ns.adobe.com/experience/offer-management/content-component-text",
                 offer.getSchema());
@@ -137,7 +139,7 @@ public class OfferTests {
 
         Assert.assertEquals("xcore:personalized-offer:3333333333333333", offer.getId());
         Assert.assertEquals("8", offer.getEtag());
-        Assert.assertEquals(0, offer.getScore());
+        Assert.assertEquals(0, offer.getScore(), doubleAccuracy);
         Assert.assertEquals(
                 "https://ns.adobe.com/experience/offer-management/content-component-html",
                 offer.getSchema());
@@ -163,7 +165,7 @@ public class OfferTests {
 
         Assert.assertEquals("xcore:personalized-offer:4444444444444444", offer.getId());
         Assert.assertEquals("8", offer.getEtag());
-        Assert.assertEquals(0, offer.getScore());
+        Assert.assertEquals(0, offer.getScore(), doubleAccuracy);
         Assert.assertEquals(
                 "https://ns.adobe.com/experience/offer-management/content-component-imagelink",
                 offer.getSchema());
@@ -189,7 +191,38 @@ public class OfferTests {
 
         Assert.assertEquals("xcore:personalized-offer:2222222222222222", offer.getId());
         Assert.assertEquals("7", offer.getEtag());
-        Assert.assertEquals(1, offer.getScore());
+        Assert.assertEquals(1, offer.getScore(), doubleAccuracy);
+        Assert.assertEquals(
+                "https://ns.adobe.com/experience/offer-management/content-component-text",
+                offer.getSchema());
+        Assert.assertEquals(OfferType.TEXT, offer.getType());
+        Assert.assertEquals(1, offer.getLanguage().size());
+        Assert.assertEquals("en-us", offer.getLanguage().get(0));
+        Assert.assertEquals("This is a plain text content!", offer.getContent());
+        Assert.assertEquals(1, offer.getCharacteristics().size());
+        Assert.assertEquals("true", offer.getCharacteristics().get("mobile"));
+    }
+
+    @Test
+    public void testFromEventData_withDoubleScore() throws Exception {
+        Map<String, Object> offerData =
+                new ObjectMapper()
+                        .readValue(
+                                getClass()
+                                        .getClassLoader()
+                                        .getResource("json/OFFER_VALID_WITH_DOUBLE_SCORE.json"),
+                                HashMap.class);
+        final Offer offer = Offer.fromEventData(offerData);
+        Assert.assertNotNull(offer);
+
+        Assert.assertEquals("xcore:personalized-offer:2222222222222222", offer.getId());
+        Assert.assertEquals("7", offer.getEtag());
+
+        // validate that the score is of type double and has the correct value
+        Object offerScore = offer.getScore();
+        Assert.assertTrue(offerScore instanceof Double);
+        Assert.assertEquals(6.43, offer.getScore(), doubleAccuracy);
+
         Assert.assertEquals(
                 "https://ns.adobe.com/experience/offer-management/content-component-text",
                 offer.getSchema());

--- a/code/optimize/src/test/resources/json/OFFER_VALID_WITH_DOUBLE_SCORE.json
+++ b/code/optimize/src/test/resources/json/OFFER_VALID_WITH_DOUBLE_SCORE.json
@@ -1,7 +1,7 @@
 {
   "id": "xcore:personalized-offer:2222222222222222",
-  "etag": "6.43",
-  "score": 1,
+  "etag": "7",
+  "score": 6.43,
   "schema": "https://ns.adobe.com/experience/offer-management/content-component-text",
   "data": {
     "id": "xcore:personalized-offer:2222222222222222",

--- a/code/optimize/src/test/resources/json/OFFER_VALID_WITH_DOUBLE_SCORE.json
+++ b/code/optimize/src/test/resources/json/OFFER_VALID_WITH_DOUBLE_SCORE.json
@@ -1,0 +1,17 @@
+{
+  "id": "xcore:personalized-offer:2222222222222222",
+  "etag": "6.43",
+  "score": 1,
+  "schema": "https://ns.adobe.com/experience/offer-management/content-component-text",
+  "data": {
+    "id": "xcore:personalized-offer:2222222222222222",
+    "format": "text/plain",
+    "content": "This is a plain text content!",
+    "language": [
+      "en-us"
+    ],
+    "characteristics": {
+      "mobile": "true"
+    }
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Changing the data type of Score property from the offer entity to double.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
