### PR TITLE
add separate cache for preview propositions

### DIFF
--- a/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/OptimizeConstants.java
+++ b/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/OptimizeConstants.java
@@ -64,6 +64,7 @@ class OptimizeConstants {
         static final String NOTIFICATION = "com.adobe.eventSource.notification";
         static final String EDGE_PERSONALIZATION_DECISIONS = "personalization:decisions";
         static final String CONTENT_COMPLETE = "com.adobe.eventSource.contentComplete";
+        static final String DEBUG = "com.adobe.eventSource.debug";
 
         private EventSource() {}
     }

--- a/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/OptimizeExtension.java
+++ b/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/OptimizeExtension.java
@@ -963,8 +963,8 @@ class OptimizeExtension extends Extension {
                 Log.debug(
                         OptimizeConstants.LOG_TAG,
                         SELF_TAG,
-                        "handleDebugEvent - Cannot process the Edge event, propositions list is"
-                                + " either null or empty in the Edge response.");
+                        "handleDebugEvent - Cannot process the Debug event, propositions list is"
+                                + " either null or empty in the response.");
                 return;
             }
 
@@ -983,8 +983,8 @@ class OptimizeExtension extends Extension {
                 Log.debug(
                         OptimizeConstants.LOG_TAG,
                         SELF_TAG,
-                        "handleDebugEvent - Cannot process the Edge event, no propositions with"
-                                + " valid offers are present in the Edge response.");
+                        "handleDebugEvent - Cannot process the Debug event, no propositions with"
+                                + " valid offers are present in the response.");
                 return;
             }
 
@@ -997,7 +997,7 @@ class OptimizeExtension extends Extension {
             final Map<String, Object> notificationData = new HashMap<>();
             notificationData.put(OptimizeConstants.EventDataKeys.PROPOSITIONS, propositionsList);
 
-            final Event edgeEvent =
+            final Event notificationEvent =
                     new Event.Builder(
                                     OptimizeConstants.EventNames.OPTIMIZE_NOTIFICATION,
                                     OptimizeConstants.EventType.OPTIMIZE,
@@ -1006,12 +1006,12 @@ class OptimizeExtension extends Extension {
                             .build();
 
             // Dispatch notification event
-            getApi().dispatch(edgeEvent);
+            getApi().dispatch(notificationEvent);
         } catch (final Exception e) {
             Log.warning(
                     OptimizeConstants.LOG_TAG,
                     SELF_TAG,
-                    "handleDebugEvent - Cannot process the Edge event due to an exception (%s)!",
+                    "handleDebugEvent - Cannot process the Debug event due to an exception (%s)!",
                     e.getLocalizedMessage());
         }
     }

--- a/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/OptimizeExtension.java
+++ b/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/OptimizeExtension.java
@@ -922,6 +922,7 @@ class OptimizeExtension extends Extension {
      */
     void handleClearPropositions(@NonNull final Event event) {
         cachedPropositions.clear();
+        previewCachedPropositions.clear();
     }
 
     /**

--- a/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/OptimizeExtension.java
+++ b/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/OptimizeExtension.java
@@ -16,6 +16,7 @@ import androidx.annotation.VisibleForTesting;
 import com.adobe.marketing.mobile.AdobeCallbackWithError;
 import com.adobe.marketing.mobile.AdobeError;
 import com.adobe.marketing.mobile.Event;
+import com.adobe.marketing.mobile.EventType;
 import com.adobe.marketing.mobile.Extension;
 import com.adobe.marketing.mobile.ExtensionApi;
 import com.adobe.marketing.mobile.MobileCore;
@@ -42,6 +43,10 @@ class OptimizeExtension extends Extension {
     // for the same Edge personalization request.
     // This is accessed from multiple threads.
     private Map<DecisionScope, OptimizeProposition> cachedPropositions = new ConcurrentHashMap<>();
+
+    // Concurrent Map containing propositions simulated for preview and cached in-memory in the SDK
+    private Map<DecisionScope, OptimizeProposition> previewCachedPropositions =
+            new ConcurrentHashMap<>();
 
     // Events dispatcher used to maintain the processing order of update and get propositions
     // events.
@@ -124,7 +129,8 @@ class OptimizeExtension extends Extension {
      *       OptimizeConstants.EventType#GENERIC_IDENTITY} and source {@value
      *       OptimizeConstants.EventSource#REQUEST_RESET} Listener for {@code Event} type {@value
      *       OptimizeConstants.EventType#OPTIMIZE} and source {@value
-     *       OptimizeConstants.EventSource#CONTENT_COMPLETE}
+     *       OptimizeConstants.EventSource#CONTENT_COMPLETE} Listener for {@code Event} type {@value
+     *       EventType#SYSTEM} and source {@value OptimizeConstants.EventSource#DEBUG}
      * </ul>
      *
      * @param extensionApi {@link ExtensionApi} instance.
@@ -166,6 +172,11 @@ class OptimizeExtension extends Extension {
                         OptimizeConstants.EventType.OPTIMIZE,
                         OptimizeConstants.EventSource.CONTENT_COMPLETE,
                         this::handleUpdatePropositionsCompleted);
+
+        getApi().registerEventListener(
+                        EventType.SYSTEM,
+                        OptimizeConstants.EventSource.DEBUG,
+                        this::handleDebugEvent);
 
         eventsDispatcher.start();
     }
@@ -784,8 +795,25 @@ class OptimizeExtension extends Extension {
                 }
             }
 
+            final List<Map<String, Object>> previewPropositionsList = new ArrayList<>();
+            for (final DecisionScope scope : validScopes) {
+                if (previewCachedPropositions.containsKey(scope)) {
+                    final OptimizeProposition optimizeProposition =
+                            previewCachedPropositions.get(scope);
+                    previewPropositionsList.add(optimizeProposition.toEventData());
+                }
+            }
+
             final Map<String, Object> responseEventData = new HashMap<>();
-            responseEventData.put(OptimizeConstants.EventDataKeys.PROPOSITIONS, propositionsList);
+
+            if (!previewPropositionsList.isEmpty()) {
+                Log.debug(OptimizeConstants.LOG_TAG, SELF_TAG, "Preview Mode is enabled.");
+                responseEventData.put(
+                        OptimizeConstants.EventDataKeys.PROPOSITIONS, previewPropositionsList);
+            } else {
+                responseEventData.put(
+                        OptimizeConstants.EventDataKeys.PROPOSITIONS, propositionsList);
+            }
 
             final Event responseEvent =
                     new Event.Builder(
@@ -897,6 +925,97 @@ class OptimizeExtension extends Extension {
     }
 
     /**
+     * Handles the event with type {@value EventType#SYSTEM} and source {@value
+     * OptimizeConstants.EventSource#DEBUG}.
+     *
+     * <p>A debug event allows the optimize extension to processes non-production workflows.
+     *
+     * @param event the debug {@link Event} to be handled.
+     */
+    void handleDebugEvent(@NonNull final Event event) {
+        try {
+            if (OptimizeUtils.isNullOrEmpty(event.getEventData())) {
+                Log.debug(
+                        OptimizeConstants.LOG_TAG,
+                        SELF_TAG,
+                        "handleDebugEvent - Ignoring the Optimize Debug event, either event is null"
+                                + " or event data is null/ empty.");
+                return;
+            }
+
+            if (!OptimizeUtils.isDebugEvent(event)) {
+                Log.debug(
+                        OptimizeConstants.LOG_TAG,
+                        SELF_TAG,
+                        "handleDebugEvent - Ignoring Optimize Debug event, either handle type is"
+                                + " not com.adobe.eventType.system or source is not"
+                                + " com.adobe.eventSource.debug");
+                return;
+            }
+
+            final Map<String, Object> eventData = event.getEventData();
+
+            final List<Map<String, Object>> payload =
+                    DataReader.getTypedListOfMap(
+                            Object.class, eventData, OptimizeConstants.Edge.PAYLOAD);
+            if (OptimizeUtils.isNullOrEmpty(payload)) {
+                Log.debug(
+                        OptimizeConstants.LOG_TAG,
+                        SELF_TAG,
+                        "handleDebugEvent - Cannot process the Edge event, propositions list is"
+                                + " either null or empty in the Edge response.");
+                return;
+            }
+
+            final Map<DecisionScope, OptimizeProposition> propositionsMap = new HashMap<>();
+            for (final Map<String, Object> propositionData : payload) {
+                final OptimizeProposition optimizeProposition =
+                        OptimizeProposition.fromEventData(propositionData);
+                if (optimizeProposition != null
+                        && !OptimizeUtils.isNullOrEmpty(optimizeProposition.getOffers())) {
+                    final DecisionScope scope = new DecisionScope(optimizeProposition.getScope());
+                    propositionsMap.put(scope, optimizeProposition);
+                }
+            }
+
+            if (OptimizeUtils.isNullOrEmpty(propositionsMap)) {
+                Log.debug(
+                        OptimizeConstants.LOG_TAG,
+                        SELF_TAG,
+                        "handleDebugEvent - Cannot process the Edge event, no propositions with"
+                                + " valid offers are present in the Edge response.");
+                return;
+            }
+
+            previewCachedPropositions.putAll(propositionsMap);
+
+            final List<Map<String, Object>> propositionsList = new ArrayList<>();
+            for (final OptimizeProposition optimizeProposition : propositionsMap.values()) {
+                propositionsList.add(optimizeProposition.toEventData());
+            }
+            final Map<String, Object> notificationData = new HashMap<>();
+            notificationData.put(OptimizeConstants.EventDataKeys.PROPOSITIONS, propositionsList);
+
+            final Event edgeEvent =
+                    new Event.Builder(
+                                    OptimizeConstants.EventNames.OPTIMIZE_NOTIFICATION,
+                                    OptimizeConstants.EventType.OPTIMIZE,
+                                    OptimizeConstants.EventSource.NOTIFICATION)
+                            .setEventData(notificationData)
+                            .build();
+
+            // Dispatch notification event
+            getApi().dispatch(edgeEvent);
+        } catch (final Exception e) {
+            Log.warning(
+                    OptimizeConstants.LOG_TAG,
+                    SELF_TAG,
+                    "handleDebugEvent - Cannot process the Edge event due to an exception (%s)!",
+                    e.getLocalizedMessage());
+        }
+    }
+
+    /**
      * Retrieves the {@code Configuration} shared state versioned at the current {@code event}.
      *
      * @param event incoming {@link Event} instance.
@@ -995,6 +1114,17 @@ class OptimizeExtension extends Extension {
     @VisibleForTesting
     void setCachedPropositions(final Map<DecisionScope, OptimizeProposition> cachedPropositions) {
         this.cachedPropositions = cachedPropositions;
+    }
+
+    @VisibleForTesting
+    Map<DecisionScope, OptimizeProposition> getPreviewCachedPropositions() {
+        return previewCachedPropositions;
+    }
+
+    @VisibleForTesting
+    void setPreviewCachedPropositions(
+            final Map<DecisionScope, OptimizeProposition> previewCachedPropositions) {
+        this.previewCachedPropositions = previewCachedPropositions;
     }
 
     @VisibleForTesting

--- a/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/OptimizeUtils.java
+++ b/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/OptimizeUtils.java
@@ -14,6 +14,7 @@ package com.adobe.marketing.mobile.optimize;
 import android.util.Base64;
 import com.adobe.marketing.mobile.AdobeError;
 import com.adobe.marketing.mobile.Event;
+import com.adobe.marketing.mobile.EventType;
 import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.util.DataReader;
 import java.util.Collection;
@@ -151,6 +152,17 @@ class OptimizeUtils {
         return OptimizeConstants.EventType.EDGE.equalsIgnoreCase(event.getType())
                 && OptimizeConstants.EventSource.ERROR_RESPONSE_CONTENT.equalsIgnoreCase(
                         event.getSource());
+    }
+
+    /**
+     * Checks whether the given event is a Debug Event returned from the Edge network.
+     *
+     * @param event instance of {@link Event}
+     * @return {@code boolean} return true if event is a debug event, false otherwise.
+     */
+    static boolean isDebugEvent(final Event event) {
+        return EventType.SYSTEM.equalsIgnoreCase(event.getType())
+                && OptimizeConstants.EventSource.DEBUG.equalsIgnoreCase(event.getSource());
     }
 
     /**

--- a/code/optimize/src/test/java/com/adobe/marketing/mobile/optimize/OptimizeExtensionTests.java
+++ b/code/optimize/src/test/java/com/adobe/marketing/mobile/optimize/OptimizeExtensionTests.java
@@ -2221,9 +2221,9 @@ public class OptimizeExtensionTests {
                                 HashMap.class);
         final Event testEvent =
                 new Event.Builder(
-                        "AEP Response Event Handle (Spoof)",
-                        "com.adobe.eventType.system",
-                        "com.adobe.eventSource.debug")
+                                "AEP Response Event Handle (Spoof)",
+                                "com.adobe.eventType.system",
+                                "com.adobe.eventSource.debug")
                         .setEventData(edgeResponseData)
                         .build();
 
@@ -2285,9 +2285,9 @@ public class OptimizeExtensionTests {
                                     HashMap.class);
             final Event testEvent =
                     new Event.Builder(
-                            "AEP Response Event Handle (Spoof)",
-                            "com.adobe.eventType.edge",
-                            "com.adobe.eventSource.debug")
+                                    "AEP Response Event Handle (Spoof)",
+                                    "com.adobe.eventType.edge",
+                                    "com.adobe.eventSource.debug")
                             .setEventData(edgeResponseData)
                             .build();
 
@@ -2320,9 +2320,9 @@ public class OptimizeExtensionTests {
                                     HashMap.class);
             final Event testEvent =
                     new Event.Builder(
-                            "AEP Response Event Handle (Spoof)",
-                            "com.adobe.eventType.system",
-                            "com.adobe.eventSource.personalization:decisions")
+                                    "AEP Response Event Handle (Spoof)",
+                                    "com.adobe.eventType.system",
+                                    "com.adobe.eventSource.personalization:decisions")
                             .setEventData(edgeResponseData)
                             .build();
 
@@ -2355,9 +2355,9 @@ public class OptimizeExtensionTests {
 
             final Event testEvent =
                     new Event.Builder(
-                            "AEP Response Event Handle (Spoof)",
-                            "com.adobe.eventType.system",
-                            "com.adobe.eventSource.debug")
+                                    "AEP Response Event Handle (Spoof)",
+                                    "com.adobe.eventType.system",
+                                    "com.adobe.eventSource.debug")
                             .setEventData(edgeResponseData)
                             .build();
 
@@ -2389,9 +2389,9 @@ public class OptimizeExtensionTests {
 
             final Event testEvent =
                     new Event.Builder(
-                            "Test Event",
-                            "com.adobe.eventType.edge",
-                            "com.adobe.eventSource.responseContent")
+                                    "Test Event",
+                                    "com.adobe.eventType.edge",
+                                    "com.adobe.eventSource.responseContent")
                             .setEventData(edgeResponseData)
                             .build();
 
@@ -2416,9 +2416,9 @@ public class OptimizeExtensionTests {
             // setup
             final Event testEvent =
                     new Event.Builder(
-                            "AEP Response Event Handle (Spoof)",
-                            "com.adobe.eventType.system",
-                            "com.adobe.eventSource.debug")
+                                    "AEP Response Event Handle (Spoof)",
+                                    "com.adobe.eventType.system",
+                                    "com.adobe.eventSource.debug")
                             .setEventData(null)
                             .build();
 
@@ -2443,9 +2443,9 @@ public class OptimizeExtensionTests {
             // setup
             final Event testEvent =
                     new Event.Builder(
-                            "AEP Response Event Handle (Spoof)",
-                            "com.adobe.eventType.system",
-                            "com.adobe.eventSource.debug")
+                                    "AEP Response Event Handle (Spoof)",
+                                    "com.adobe.eventType.system",
+                                    "com.adobe.eventSource.debug")
                             .setEventData(new HashMap<>())
                             .build();
 

--- a/code/optimize/src/test/java/com/adobe/marketing/mobile/optimize/OptimizeExtensionTests.java
+++ b/code/optimize/src/test/java/com/adobe/marketing/mobile/optimize/OptimizeExtensionTests.java
@@ -12,6 +12,7 @@
 package com.adobe.marketing.mobile.optimize;
 
 import android.util.Base64;
+import com.adobe.marketing.mobile.AdobeError;
 import com.adobe.marketing.mobile.Event;
 import com.adobe.marketing.mobile.ExtensionApi;
 import com.adobe.marketing.mobile.ExtensionEventListener;
@@ -27,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,6 +45,8 @@ import org.mockito.stubbing.Answer;
 @SuppressWarnings("unchecked")
 public class OptimizeExtensionTests {
     private OptimizeExtension extension;
+    private Map<DecisionScope, OptimizeProposition> responseMap;
+    private AdobeError responseError;
 
     // Mocks
     @Mock ExtensionApi mockExtensionApi;
@@ -55,6 +59,12 @@ public class OptimizeExtensionTests {
         extension.onRegistered();
 
         Mockito.clearInvocations(mockExtensionApi);
+    }
+
+    @After
+    public void teardown() {
+        responseMap = null;
+        responseError = null;
     }
 
     @Test
@@ -2250,7 +2260,17 @@ public class OptimizeExtensionTests {
                 OptimizeProposition.fromEventData(propositionsData);
         Assert.assertNotNull(optimizeProposition);
 
+        // for debug events propositions should be cached
+        // in the preview cache and not in the main cache
+        Assert.assertEquals(0, extension.getCachedPropositions().size());
+        Assert.assertEquals(1, extension.getPreviewCachedPropositions().size());
+
         Assert.assertEquals("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", optimizeProposition.getId());
+
+        Map.Entry<DecisionScope, OptimizeProposition> cachedPropositionEntry =
+                extension.getPreviewCachedPropositions().entrySet().iterator().next();
+        Assert.assertEquals(optimizeProposition.getId(), cachedPropositionEntry.getValue().getId());
+
         Assert.assertEquals(
                 "eyJhY3Rpdml0eUlkIjoieGNvcmU6b2ZmZXItYWN0aXZpdHk6MTExMTExMTExMTExMTExMSIsInBsYWNlbWVudElkIjoieGNvcmU6b2ZmZXItcGxhY2VtZW50OjExMTExMTExMTExMTExMTEifQ==",
                 optimizeProposition.getScope());
@@ -2268,6 +2288,92 @@ public class OptimizeExtensionTests {
         Assert.assertEquals(1, offer.getCharacteristics().size());
         Assert.assertEquals("true", offer.getCharacteristics().get("testing"));
         Assert.assertNull(offer.getLanguage());
+    }
+
+    @Test
+    public void testHandleDebugEvent_getPropositionsForMultipleScopes() throws Exception {
+        // setup
+        final Map<String, Object> testPropositionDataA =
+                new ObjectMapper()
+                        .readValue(
+                                getClass()
+                                        .getClassLoader()
+                                        .getResource("json/PROPOSITION_VALID.json"),
+                                HashMap.class);
+        final OptimizeProposition testOptimizePropositionA =
+                OptimizeProposition.fromEventData(testPropositionDataA);
+        Assert.assertNotNull(testOptimizePropositionA);
+        final Map<DecisionScope, OptimizeProposition> cachedPropositions = new HashMap<>();
+        cachedPropositions.put(
+                new DecisionScope(testOptimizePropositionA.getScope()), testOptimizePropositionA);
+
+        final Map<String, Object> testPropositionDataB =
+                new ObjectMapper()
+                        .readValue(
+                                getClass()
+                                        .getClassLoader()
+                                        .getResource("json/PROPOSITION_VALID_B.json"),
+                                HashMap.class);
+        final OptimizeProposition testOptimizePropositionB =
+                OptimizeProposition.fromEventData(testPropositionDataB);
+        Assert.assertNotNull(testOptimizePropositionB);
+        cachedPropositions.put(
+                new DecisionScope(testOptimizePropositionB.getScope()), testOptimizePropositionB);
+
+        extension.setCachedPropositions(cachedPropositions);
+
+        // send a debug event with data of Decision Scope B
+        final Map<String, Object> edgeResponseData =
+                new ObjectMapper()
+                        .readValue(
+                                getClass()
+                                        .getClassLoader()
+                                        .getResource("json/EVENT_DATA_EDGE_RESPONSE_VALID.json"),
+                                HashMap.class);
+        final Event testEvent =
+                new Event.Builder(
+                                "AEP Response Event Handle (Spoof)",
+                                "com.adobe.eventType.system",
+                                "com.adobe.eventSource.debug")
+                        .setEventData(edgeResponseData)
+                        .build();
+
+        final ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+
+        // test
+        extension.handleDebugEvent(testEvent);
+
+        // verify
+        Mockito.verify(mockExtensionApi, Mockito.times(1)).dispatch(eventCaptor.capture());
+
+        final Event dispatchedEvent = eventCaptor.getValue();
+        Assert.assertEquals("com.adobe.eventType.optimize", dispatchedEvent.getType());
+        Assert.assertEquals("com.adobe.eventSource.notification", dispatchedEvent.getSource());
+
+        final List<Map<String, Object>> propositionsList =
+                (List<Map<String, Object>>) dispatchedEvent.getEventData().get("propositions");
+        Assert.assertNotNull(propositionsList);
+        Assert.assertEquals(1, propositionsList.size());
+
+        final Map<String, Object> propositionsData = propositionsList.get(0);
+        Assert.assertNotNull(propositionsData);
+        final OptimizeProposition optimizeProposition =
+                OptimizeProposition.fromEventData(propositionsData);
+        Assert.assertNotNull(optimizeProposition);
+
+        // decision scopes A and B should be cached in normal cache
+        Assert.assertEquals(2, extension.getCachedPropositions().size());
+
+        // decision scope B should be cached in preview cache
+        Assert.assertEquals(1, extension.getPreviewCachedPropositions().size());
+        Map.Entry<DecisionScope, OptimizeProposition> previewCachedPropositionEntry =
+                extension.getPreviewCachedPropositions().entrySet().iterator().next();
+        Assert.assertEquals(
+                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                previewCachedPropositionEntry.getValue().getId());
+        Assert.assertEquals(
+                "eyJhY3Rpdml0eUlkIjoieGNvcmU6b2ZmZXItYWN0aXZpdHk6MTExMTExMTExMTExMTExMSIsInBsYWNlbWVudElkIjoieGNvcmU6b2ZmZXItcGxhY2VtZW50OjExMTExMTExMTExMTExMTEifQ==",
+                previewCachedPropositionEntry.getValue().getScope());
     }
 
     @Test

--- a/code/optimize/src/test/resources/json/EVENT_DATA_EDGE_RESPONSE_PROPOSITION_WITH_EMPTY_OFFER.json
+++ b/code/optimize/src/test/resources/json/EVENT_DATA_EDGE_RESPONSE_PROPOSITION_WITH_EMPTY_OFFER.json
@@ -1,0 +1,20 @@
+{
+  "payload": [
+    {
+      "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+      "scope": "eyJhY3Rpdml0eUlkIjoieGNvcmU6b2ZmZXItYWN0aXZpdHk6MTExMTExMTExMTExMTExMSIsInBsYWNlbWVudElkIjoieGNvcmU6b2ZmZXItcGxhY2VtZW50OjExMTExMTExMTExMTExMTEifQ==",
+      "activity": {
+        "etag": "8",
+        "id": "xcore:offer-activity:1111111111111111"
+      },
+      "placement": {
+        "etag": "1",
+        "id": "xcore:offer-placement:1111111111111111"
+      },
+      "items": []
+    }
+  ],
+  "requestEventId": "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA",
+  "requestId": "BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB",
+  "type": "personalization:decisions"
+}

--- a/code/optimize/src/test/resources/json/PROPOSITION_VALID_B.json
+++ b/code/optimize/src/test/resources/json/PROPOSITION_VALID_B.json
@@ -1,0 +1,27 @@
+{
+  "id":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+  "items":[
+    {
+      "id":"xcore:personalized-offer:1111111111111111",
+      "etag":"10",
+      "schema":"https://ns.adobe.com/experience/offer-management/content-component-html",
+      "data":{
+        "id":"xcore:personalized-offer:1111111111111111",
+        "format":"text/html",
+        "content":"<h1>This is a HTML content</h1>",
+        "characteristics": {
+          "testing": "true"
+        }
+      }
+    }
+  ],
+  "placement":{
+    "etag":"1",
+    "id":"xcore:offer-placement:1111111111111111"
+  },
+  "activity":{
+    "etag":"8",
+    "id":"xcore:offer-activity:1111111111111111"
+  },
+  "scope":"eyJhY3Rpdml0eUlkIjoieGNvcmU6b2ZmZXItYWN0aXZpdHk6MTExMTExMTExMTExMTExMSIsInBsYWNlbWVudElkIjoieGNvcmU6b2ZmZXItcGxhY2VtZW50OjExMTExMTExMTExMTExMTEifQ=="
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
In this PR we've added a separate preview cache and modified handling of get proposition to provide requested data from preview cache if present.


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
