### PR TITLE
Revert "Changing config timeout scale from seconds to milliseconds"

### DIFF
--- a/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/ConfigsUtils.kt
+++ b/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/ConfigsUtils.kt
@@ -24,7 +24,7 @@ object ConfigsUtils {
         return try {
             val eventTimeout = DataReader.getLong(eventData, OptimizeConstants.EventDataKeys.TIMEOUT)
             if (eventTimeout == Long.MAX_VALUE)
-                DataReader.getLong(configData, OptimizeConstants.EventDataKeys.CONFIGS_TIMEOUT)
+                DataReader.getLong(configData, OptimizeConstants.EventDataKeys.CONFIGS_TIMEOUT).times(OptimizeConstants.TIMEOUT_CONVERSION_FACTOR)
             else eventTimeout
         } catch (e: DataReaderException) {
             defaultTimeout

--- a/code/optimize/src/test/java/com/adobe/marketing/mobile/optimize/ConfigsUtilsTests.kt
+++ b/code/optimize/src/test/java/com/adobe/marketing/mobile/optimize/ConfigsUtilsTests.kt
@@ -50,7 +50,7 @@ class ConfigsUtilsTests {
     fun `returns timeout from configData when eventData contains Long_MAX_VALUE`() {
         val eventData = mapOf(OptimizeConstants.EventDataKeys.TIMEOUT to Long.MAX_VALUE)
         val configData =
-            mapOf<String, Any?>(OptimizeConstants.EventDataKeys.CONFIGS_TIMEOUT to 7000)
+            mapOf<String, Any?>(OptimizeConstants.EventDataKeys.CONFIGS_TIMEOUT to 7)
         every { mockEvent.eventData } returns eventData
 
         Assert.assertEquals(7000L, mockEvent.retrieveOptimizeRequestTimeout(configData))


### PR DESCRIPTION
Reverts adobe/aepsdk-optimize-android#161