### PR TITLE
[MOB-23379] Adding Methods to expose the generateInteractionXdm for multiple display propositions

### DIFF
--- a/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/OfferUtils.kt
+++ b/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/OfferUtils.kt
@@ -42,7 +42,7 @@ object OfferUtils {
      * proposition ID and generates XDM data for the interaction.
      *
      * @return [Map] containing the XDM data for the proposition interaction, or null if the list is empty
-     *         or no valid propositions are found
+     * or no valid propositions are found
      */
     @JvmStatic
     fun List<Offer>.generateDisplayInteractionXdm(): Map<String, Any>? {

--- a/code/optimize/src/test/java/com/adobe/marketing/mobile/optimize/OfferUtilsTest.kt
+++ b/code/optimize/src/test/java/com/adobe/marketing/mobile/optimize/OfferUtilsTest.kt
@@ -33,7 +33,6 @@ class OfferUtilsTest {
     @Before
     fun setUp() {
         mockkStatic(XDMUtils::trackWithData)
-        mockkStatic(XDMUtils::generateInteractionXdm)
 
         val multipleItemsList: List<Map<String, Any>> =
             loadJsonFromFile("json/MULTIPLE_OFFERS_WITH_COMMON_PROPOSITIONS.json") ?: emptyList()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

To track display interactions involving multiple offers from different propositions, you can now batch them into a single XDM payload and send a consolidated tracking event. This is particularly useful when multiple offers from various propositions are displayed together within a single activity or screen.


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
