### PR TITLE
MOB-23669 : Removing return statements for error while parsing callback event

### DIFF
--- a/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/Optimize.java
+++ b/code/optimize/src/main/java/com/adobe/marketing/mobile/optimize/Optimize.java
@@ -234,15 +234,6 @@ public class Optimize {
                                             AEPOptimizeError.Companion.getUnexpectedError();
                                     failWithOptimizeError(callback, aepOptimizeError);
                                 }
-                                return;
-                            }
-
-                            if (!eventData.containsKey(
-                                    OptimizeConstants.EventDataKeys.PROPOSITIONS)) {
-                                AEPOptimizeError aepOptimizeError =
-                                        AEPOptimizeError.Companion.getUnexpectedError();
-                                failWithOptimizeError(callback, aepOptimizeError);
-                                return;
                             }
 
                             final List<Map<String, Object>> propositionsList;

--- a/code/optimize/src/test/java/com/adobe/marketing/mobile/optimize/OptimizeTests.java
+++ b/code/optimize/src/test/java/com/adobe/marketing/mobile/optimize/OptimizeTests.java
@@ -225,7 +225,7 @@ public class OptimizeTests {
     }
 
     @Test
-    public void testUpdatePropositionsWithCallback_validDecisionScopeWithError() throws Exception {
+    public void testUpdatePropositionsWithCallback_SuccessWithError() throws Exception {
         try (MockedStatic<MobileCore> mobileCoreMockedStatic =
                         Mockito.mockStatic(MobileCore.class);
                 MockedStatic<Base64> base64MockedStatic = Mockito.mockStatic(Base64.class)) {

--- a/code/optimize/src/test/java/com/adobe/marketing/mobile/optimize/OptimizeTests.java
+++ b/code/optimize/src/test/java/com/adobe/marketing/mobile/optimize/OptimizeTests.java
@@ -41,11 +41,13 @@ import org.mockito.stubbing.Answer;
 public class OptimizeTests {
     private Map<DecisionScope, OptimizeProposition> responseMap;
     private AdobeError responseError;
+    private AEPOptimizeError optimizeError;
 
     @After
     public void teardown() {
         responseMap = null;
         responseError = null;
+        optimizeError = null;
     }
 
     @Test
@@ -219,6 +221,111 @@ public class OptimizeTests {
             callbackWithError.call(responseEvent);
 
             Assert.assertNull(responseError);
+        }
+    }
+
+    @Test
+    public void testUpdatePropositionsWithCallback_validDecisionScopeWithError() throws Exception {
+        try (MockedStatic<MobileCore> mobileCoreMockedStatic =
+                        Mockito.mockStatic(MobileCore.class);
+                MockedStatic<Base64> base64MockedStatic = Mockito.mockStatic(Base64.class)) {
+            // setup
+            base64MockedStatic
+                    .when(
+                            () ->
+                                    Base64.decode(
+                                            ArgumentMatchers.anyString(),
+                                            ArgumentMatchers.anyInt()))
+                    .thenAnswer(
+                            (Answer<byte[]>)
+                                    invocation ->
+                                            java.util.Base64.getDecoder()
+                                                    .decode((String) invocation.getArguments()[0]));
+
+            // test
+            final List<DecisionScope> scopes = new ArrayList<>();
+            scopes.add(
+                    new DecisionScope(
+                            "eyJhY3Rpdml0eUlkIjoieGNvcmU6b2ZmZXItYWN0aXZpdHk6MTExMTExMTExMTExMTExMSIsInBsYWNlbWVudElkIjoieGNvcmU6b2ZmZXItcGxhY2VtZW50OjExMTExMTExMTExMTExMTEifQ=="));
+
+            Optimize.updatePropositions(
+                    scopes,
+                    null,
+                    null,
+                    new AdobeCallbackWithOptimizeError<Map<DecisionScope, OptimizeProposition>>() {
+                        @Override
+                        public void fail(AEPOptimizeError adobeError) {
+                            optimizeError = adobeError;
+                        }
+
+                        @Override
+                        public void call(Map<DecisionScope, OptimizeProposition> propositionsMap) {
+                            responseMap = propositionsMap;
+                        }
+                    });
+
+            final ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+            final ArgumentCaptor<AdobeCallbackWithError<Event>> callbackCaptor =
+                    ArgumentCaptor.forClass(AdobeCallbackWithError.class);
+
+            mobileCoreMockedStatic.verify(
+                    () ->
+                            MobileCore.dispatchEventWithResponseCallback(
+                                    eventCaptor.capture(),
+                                    ArgumentMatchers.anyLong(),
+                                    callbackCaptor.capture()));
+
+            final Event event = eventCaptor.getValue();
+            final AdobeCallbackWithError<Event> callbackWithError = callbackCaptor.getValue();
+
+            Assert.assertNotNull(event);
+            Assert.assertEquals("com.adobe.eventType.optimize", event.getType());
+            Assert.assertEquals("com.adobe.eventSource.requestContent", event.getSource());
+
+            final Map<String, Object> eventData = event.getEventData();
+            Assert.assertEquals("updatepropositions", eventData.get("requesttype"));
+
+            final List<Map<String, Object>> scopesList =
+                    (List<Map<String, Object>>) eventData.get("decisionscopes");
+            Assert.assertEquals(1, scopesList.size());
+
+            final Map<String, Object> scopeData = scopesList.get(0);
+            Assert.assertNotNull(scopeData);
+            Assert.assertEquals(1, scopeData.size());
+            Assert.assertEquals(
+                    "eyJhY3Rpdml0eUlkIjoieGNvcmU6b2ZmZXItYWN0aXZpdHk6MTExMTExMTExMTExMTExMSIsInBsYWNlbWVudElkIjoieGNvcmU6b2ZmZXItcGxhY2VtZW50OjExMTExMTExMTExMTExMTEifQ==",
+                    scopeData.get("name"));
+
+            // verify callback response
+            final Map<String, Object> propositionData =
+                    new ObjectMapper()
+                            .readValue(
+                                    getClass()
+                                            .getClassLoader()
+                                            .getResource("json/PROPOSITION_VALID_ODE.json"),
+                                    HashMap.class);
+            final OptimizeProposition optimizeProposition =
+                    OptimizeProposition.fromEventData(propositionData);
+            Assert.assertNotNull(optimizeProposition);
+
+            final List<Map<String, Object>> propositionsList = new ArrayList<>();
+            propositionsList.add(optimizeProposition.toEventData());
+
+            final Map<String, Object> responseEventData = new HashMap<>();
+            responseEventData.put("propositions", propositionsList);
+            responseEventData.put(
+                    "responseerror", AEPOptimizeError.Companion.getUnexpectedError().toEventData());
+            final Event responseEvent =
+                    new Event.Builder(
+                                    "Optimize Response",
+                                    "com.adobe.eventType.optimize",
+                                    "com.adobe.eventSource.responseContent")
+                            .setEventData(responseEventData)
+                            .build();
+            callbackWithError.call(responseEvent);
+
+            Assert.assertNotNull(optimizeError);
+            Assert.assertNotNull(responseMap);
         }
     }
 


### PR DESCRIPTION
MOB-23669 : Removing return statements for error while parsing callback event

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
